### PR TITLE
Fix Make XWRITE to blk4 committ early

### DIFF
--- a/src/firmware/vic/mem.pio
+++ b/src/firmware/vic/mem.pio
@@ -36,13 +36,16 @@ start:
     mov osr pins        ; Capture D[7:0],D[11:8],A[13:0],RnW
     out y 12            ; Keep D[11:0] in y (in case BLK4)
     in osr 14           ; shift in bottom address
-    wait 1 pin 26       ; Wait for RnW rising edge before capturing not BLK4 data
-    push noblock   [20] ; Send address to FIFO + 200ns data setup time
-    mov isr pins        ; Assume not BLK4, capture new data in isr
+    push noblock        ; Send address to FIFO
     jmp pin not_blk4    ; If A13=='1', this write is not for BLK4
     mov isr y           ; BLK4 write, use data from y
+    jmp push_data
 not_blk4:
+    wait 1 pin 26  [20] ; Wait for RnW rising edge before capturing not BLK4 data
+    mov isr pins        ; Assume not BLK4, capture new data in isr
+push_data:
     push noblock        ; Send data to FIFO
+    wait 1 pin 26       ; Safe guard
 .wrap
 
 ; Direction control of data bus


### PR DESCRIPTION
The original XWRITE PIO program waits until the VIC phase of the PHI clock before pushing address and data. This is to support the snooping of non-BLK4 writes to BLK1 RAMs as that is read during VIC phase based on the residual CPU address information. The problem is that BLK4 writes like registers then becomes available too late for the VIC emulation loops to handle same cycle writes.

The fix committs (pushes) BLK4 writes during the CPU phase of the PHI clock and only delays committing snoops.