### PR TITLE
Added missing look up of border colour before outputting last 4 border pixels prior to hblanking

### DIFF
--- a/src/firmware/vic/vic_pal.c
+++ b/src/firmware/vic/vic_pal.c
@@ -526,6 +526,7 @@ void vic_core1_loop_pal(void) {
                                     // a different state for the first part of the first video matrix line.
                                     fetchState = FETCH_IN_MATRIX_Y;
                                 }
+                                borderColour = border_colour_index;
                                 pio_sm_put(CVBS_PIO, CVBS_SM, pal_palette[borderColour]);
                                 pio_sm_put(CVBS_PIO, CVBS_SM, pal_palette[borderColour]);
                                 pio_sm_put(CVBS_PIO, CVBS_SM, pal_palette[borderColour]);


### PR DESCRIPTION
In the code block that handles outputting the last 3.66 pixels before the horizontal blanking starts, it does not look up the latest border colour before using it, so uses an old cached value from the previous cycle. This would mean that if the border colour changed between those two VIC loop cycles, it would be outputting the wrong colour for those last few pixels before hblanking.

This PR fixes this issue. It existed only for the PAL loop. NTSC was already correct.
