### PR TITLE
Add support for LOCI mode detection

### DIFF
--- a/src/firmware/main.h
+++ b/src/firmware/main.h
@@ -154,6 +154,10 @@ bool main_prog(uint16_t *xregs);
 #define XDIR_PIO pio2
 #define XDIR_SM 2
 
+#define XULA_PIN_OFFS PIO2_PIN_OFFS
+#define XULA_PIO pio2 
+#define XULA_SM 3
+
 #define RGBS_PIN_BASE 2
 #define SYNC_PIN 2
 #define R_PIN 3

--- a/src/firmware/oric/ula.pio
+++ b/src/firmware/oric/ula.pio
@@ -18,7 +18,7 @@
  irq prev 0 side 0 [14]     ;sync RGBS PIO program in pio#-1
  nop        side 0 [ 6]
  irq 1      side 0 [15]     ;second ULA phase irq - trigger first decode program phase (IO)
- nop        side 0 [ 6]     ;
+ irq next 1 side 0 [ 6]     ;trigger xula ending data output
  irq 2      side 1 [15]     ;CPU phase irq - trigger second decode program phase (MAP)
  nop        side 1 [ 6]
 .wrap
@@ -60,6 +60,7 @@ series:
     wait 0 gpio 29 [31] ; sample address ca 300ns after phi0 falling edge
     mov isr x      [10] ; Base address to fetch from in the system
     in pins 16          ; Pull in rest of address from 6502
+    wait 1 gpio 29      ; Wait rising edge of phi0
     out pins 8          ; Blocking till data returns. pindirs set elsewhere
     wait 1 gpio 29      ; Make sure only one iteration per phi clock
 .wrap
@@ -96,9 +97,27 @@ dir_out:
     jmp !y start        ; If write, abort output
     set pins 0          ; Set DIR on external bus transciver to output
     mov pindirs ~null   ; Set data pins to output
-    wait 0 gpio 29 [30] ; Wait for phi0 falling edge + ca 40 + 60ns for data hold
-    mov pindirs null    ; Disable data pins output
-    set pins 1          ; Set DIR on external bus transciver to input
+    ;data output disable now in xula program
+.wrap
+
+; Output screen data during ULA owned phase of clock
+; Partly mimics real ULA access to screen memory 
+; so that e.g. LOCI can detect screen mode
+; TODO consider replacing with API function to save PIO resources
+
+.program xula
+.set 1
+.out 8 right
+.wrap_target
+    wait 0 gpio 29 [30] ; Wait for falling edge of phi0 (beginning of ULA phase of bus cycle)
+    pull noblock        ; Get data - but don't block if not ready
+    out pins 8          ; Put data in output buffer
+    set pins 0          ; Set DIR on external bus transciever to output
+    mov pindirs ~null   ; Set data pins to output
+    wait 1 irq 1        ; Wait for singnal from phi program (and clear it)
+    mov pindirs null    ; Set data pins to input
+    set pins 1          ; Set DIR on external bus transciever to input
+    wait 1 gpio 29 [30] ; Wait for rising edge on phi0
 .wrap
 
 ; Decode logic for driving DIR and indirectly nROMSEL and nIO


### PR DESCRIPTION
Add XULA PIO program and integration to output screen data during ULA phase of clock. Used by LOCI to detect active screen mode. This passive mode may be replaced with an active API based solution in the future.