### PR TITLE
Feature DVI audio

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "src/pico_hdmi"]
 	path = src/pico_hdmi
 	url = https://github.com/fliperama86/pico_hdmi
+[submodule "src/emu2149"]
+	path = src/emu2149
+	url = https://github.com/digital-sound-antiques/emu2149

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "src/tinyusb"]
 	path = src/tinyusb
 	url = https://github.com/hathach/tinyusb.git
+[submodule "src/pico_hdmi"]
+	path = src/pico_hdmi
+	url = https://github.com/fliperama86/pico_hdmi

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,6 +28,7 @@ target_include_directories(ocula PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}
     ${CMAKE_CURRENT_LIST_DIR}/tinyusb/src
     ${CMAKE_CURRENT_LIST_DIR}/pico_hdmi/include
+    ${CMAKE_CURRENT_LIST_DIR}/emu2149
     firmware
 )
 
@@ -44,6 +45,7 @@ target_sources(ocula PRIVATE
     firmware/mon/ram.c
     firmware/mon/set.c
     firmware/mon/vip.c
+    firmware/oric/aud.c
     firmware/oric/rst.c
     firmware/oric/ula.c
     firmware/oric/ula_dvi.c
@@ -66,6 +68,7 @@ target_sources(ocula PRIVATE
     littlefs/lfs.c
     littlefs/lfs_util.c
     pico_hdmi/src/hstx_packet.c
+    emu2149/emu2149.c
 )
 
 target_link_libraries(ocula PRIVATE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,7 @@ pico_set_linker_script(ocula ${CMAKE_CURRENT_LIST_DIR}/memmap_xram_rp2350.ld)
 target_include_directories(ocula PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}
     ${CMAKE_CURRENT_LIST_DIR}/tinyusb/src
+    ${CMAKE_CURRENT_LIST_DIR}/pico_hdmi/include
     firmware
 )
 
@@ -51,6 +52,7 @@ target_sources(ocula PRIVATE
     firmware/sys/com.c
     firmware/sys/cpu.c
     firmware/sys/dvi.c
+    firmware/sys/dvi_audio.c
     firmware/sys/lfs.c
     firmware/sys/mem.c
     firmware/sys/sys.c
@@ -63,6 +65,7 @@ target_sources(ocula PRIVATE
     firmware/usb/serno.c
     littlefs/lfs.c
     littlefs/lfs_util.c
+    pico_hdmi/src/hstx_packet.c
 )
 
 target_link_libraries(ocula PRIVATE
@@ -107,6 +110,7 @@ pico_set_linker_script(pivic ${CMAKE_CURRENT_LIST_DIR}/memmap_xram_rp2350.ld)
 target_include_directories(pivic PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}
     ${CMAKE_CURRENT_LIST_DIR}/tinyusb/src
+    ${CMAKE_CURRENT_LIST_DIR}/pico_hdmi/include
     firmware
 )
 
@@ -136,6 +140,7 @@ target_sources(pivic PRIVATE
     firmware/sys/com.c
     firmware/sys/cpu.c
     firmware/sys/dvi.c
+    firmware/sys/dvi_audio.c
     firmware/sys/lfs.c
     firmware/sys/mem.c
     firmware/sys/rev.c
@@ -151,6 +156,7 @@ target_sources(pivic PRIVATE
     littlefs/lfs_util.c
     #Testing PIVIC parts
     firmware/vic/cvbs.c
+    pico_hdmi/src/hstx_packet.c
 )
 
 target_link_libraries(pivic PRIVATE

--- a/src/firmware/main.c
+++ b/src/firmware/main.c
@@ -29,6 +29,7 @@
 #include "tusb.h"
 
 #ifdef OCULA
+#include "oric/aud.h"
 #include "oric/rst.h"
 #include "oric/ula.h"
 #endif
@@ -73,6 +74,7 @@ static void init(void)
     pot_init();
 #endif
 #ifdef OCULA
+    aud_init();
     ula_init();
 #endif
     dvi_init();
@@ -92,6 +94,7 @@ static void task(void)
 #endif
 #ifdef OCULA
     ula_task();
+    aud_task();
 #endif 
     //vga_task();
     //term_task();

--- a/src/firmware/main.c
+++ b/src/firmware/main.c
@@ -16,6 +16,7 @@
 #include "sys/clk.h"
 #include "sys/cpu.h"
 #include "sys/dvi.h"
+#include "sys/dvi_audio.h"
 #include "sys/lfs.h"
 #include "sys/rev.h"
 #include "sys/sys.h"
@@ -75,6 +76,7 @@ static void init(void)
     ula_init();
 #endif
     dvi_init();
+    dvi_audio_init();
 }
 
 static void task(void)
@@ -99,6 +101,7 @@ static void task(void)
     com_task();
     mon_task();
     //ram_task();
+    dvi_audio_task();
 }
 
 void main_flush(void)

--- a/src/firmware/main.h
+++ b/src/firmware/main.h
@@ -84,6 +84,8 @@ bool main_prog(uint16_t *xregs);
 #define AUDIO_PWM_PIN 2
 #define AUDIO_PWM_SLICE 1
 #define AUDIO_PWM_CH  PWM_CHAN_A
+#define AUDIO_SAMPLE_PWM_SLICE 2
+#define AUIDO_SAMPLE_PWM_CH PWM_CHAN_A
 
 #define DATA_PIN_BASE 20
 #define DATA_PIN_COUNT 8

--- a/src/firmware/mon/hlp.c
+++ b/src/firmware/mon/hlp.c
@@ -28,9 +28,10 @@ static const char __in_flash("helptext") hlp_text_set[] =
     // "SET CAPS (0|1|2)    - Invert or force caps while 6502 is running.\n"
     // "SET PHI2 (kHz)      - Query or set PHI2 speed. This is the 6502 clock.\n"
     // "SET BOOT (rom|-)    - Select ROM to boot from cold start. \"-\" for none.\n"
-    "SET SPLASH (0|1)    - Disable or enable splash screen.\n"
-    "SET DVI (0|1|2)     - Query or set display type for DVI output.\n"
-    "SET MODE (0|1|2|3)  - Query or set main operational mode.";
+    "SET SPLASH (0|1)    - Query or set  splash screen disable or enable.\n"
+    "SET DVI (0|1|2|..)  - Query or set display type for DVI output.\n"
+    "SET AUDIO (0|1)     - Query or set DVI audio disable or enable.\n"
+    "SET MODE (0|1|2|..) - Query or set main operational mode.";
 
 static const char __in_flash("helptext") hlp_text_about[] =
     "    OCULA & PIVIC - Copyright (c) 2025 Sodiumlightbaby & Dreamseal\n"
@@ -164,7 +165,13 @@ static const char __in_flash("helptext") hlp_text_dvi[] =
     "DVI modes available depends on emulation mode.\n"
     "Use SET DVI without argument for list of DVI modes";
 
-static const char __in_flash("helptext") hlp_text_mode[] =
+static const char __in_flash("helptext") hlp_text_dvi_audio[] =
+    "SET AUDIO disables or enables DVI digital audio.\n"
+    "Some monitors need DVI audio disabled to accept the display stream.\n"
+    " 0 - disable DVI audio\n"
+    " 1 - enable DVI audio";
+
+    static const char __in_flash("helptext") hlp_text_mode[] =
 #ifdef PIVIC
     "SET MODE selects the type of VIC emulation\n"
     "  0 - VIC 6560 NTSC/60 CVBS on Luma\n"
@@ -261,6 +268,7 @@ static struct
     {4, "boot", hlp_text_boot},
     {6, "splash", hlp_text_splash},
     {3, "dvi", hlp_text_dvi},
+    {5, "audio", hlp_text_dvi_audio},
     {4, "mode", hlp_text_mode},
 };
 static const size_t SETTINGS_COUNT = sizeof SETTINGS / sizeof *SETTINGS;
@@ -273,7 +281,7 @@ static uint32_t hlp_roms_list(uint32_t width)
     uint32_t col = 0;
     lfs_dir_t lfs_dir;
     struct lfs_info lfs_info;
-    int result = lfs_dir_open(&lfs_volume, &lfs_dir, "");
+    int result = lfs_dir_open(&lfs_volume, &lfs_dir, "/");
     if (result < 0)
     {
         printf("?Unable to open ROMs directory (%d)\n", result);

--- a/src/firmware/mon/set.c
+++ b/src/firmware/mon/set.c
@@ -109,7 +109,7 @@ static void set_caps(const char *args, size_t len)
 
 static void set_print_splash()
 {
-    printf("SPLASH: %d\n", cfg_get_splash() ? "1 - On" : "0 - Off");
+    printf("SPLASH: %s\n", cfg_get_splash() ? "1 - On" : "0 - Off");
 }
 
 static void set_splash(const char *args, size_t len)
@@ -131,7 +131,7 @@ static void set_splash(const char *args, size_t len)
 static void set_print_dvi(void)
 {
     uint8_t mode = cfg_get_dvi();
-    printf("DVI mode %d\n", mode);
+    printf("DVI   : %d\n", mode);
 #ifdef PIVIC
     vic_print_dvi_modes();
 #endif
@@ -157,6 +157,31 @@ static void set_dvi(const char *args, size_t len)
         }
     }
     set_print_dvi();
+}
+
+static void set_print_dvi_audio(void)
+{
+    uint8_t enable = cfg_get_dvi_audio();
+    printf("AUDIO : %s\n", enable ? "1 - enabled" : "0 - disabled");
+}
+
+static void set_dvi_audio(const char *args, size_t len)
+{
+    uint32_t val;
+    if (len)
+    {
+        if (parse_uint32(&args, &len, &val) &&
+            parse_end(args, len))
+        {
+            cfg_set_dvi_audio(val);
+        }
+        else
+        {
+            printf("?invalid argument\n");
+            return;
+        }
+    }
+    set_print_dvi_audio();
 }
 
 static void set_print_mode()
@@ -209,6 +234,7 @@ static struct
     {4, "boot", set_boot},
     {6, "splash", set_splash},
     {3, "dvi", set_dvi},
+    {5, "audio", set_dvi_audio},
     {4, "mode", set_mode}
 };
 static const size_t SETTERS_COUNT = sizeof SETTERS / sizeof *SETTERS;
@@ -220,6 +246,7 @@ static void set_print_all(void)
     // set_print_boot();
     set_print_splash();
     set_print_dvi();
+    set_print_dvi_audio();
     set_print_mode();
 }
 

--- a/src/firmware/oric/aud.c
+++ b/src/firmware/oric/aud.c
@@ -21,10 +21,11 @@
 
 //Static allocation instead of using PSG_new
 PSG psg;
-audio_sample_t psg_sample;
+volatile audio_sample_t psg_sample;
 
 void aud_init(void){
-    PSG_setClock(&psg, 1000000/2);
+    PSG_setClock(&psg, 1000000);
+    PSG_setClockDivider(&psg, 0);
     PSG_setRate(&psg, DVI_AUDIO_FS);
     PSG_setVolumeMode(&psg, 2); // AY style
     PSG_setQuality(&psg, 0);
@@ -34,14 +35,16 @@ void aud_init(void){
 }
 
 void aud_task(void){
-    static uint32_t ay_addr;
     //TODO This is not good buffer filling. Needs rework.
-    if(!dvi_audio_buf_is_full()){
+    if(dvi_audio_fs_tick()){
         uint16_t sample = PSG_calc(&psg);
         psg_sample.left = sample;
         psg_sample.right = sample;
     }
+}
 
+void aud_tick(void){
+    static uint32_t ay_addr;
     //CA2 -> BC1
     //CB2 -> BDIR
     //VIA CA2/CB2: C = 0, E = 1
@@ -53,7 +56,6 @@ void aud_task(void){
     if((pcr & 0xEE) == 0xEC){
         PSG_writeReg(&psg, ay_addr, VIA_ORA & VIA_DRA);
     }
-   
 }
 
 void aud_print_status(void){

--- a/src/firmware/oric/aud.c
+++ b/src/firmware/oric/aud.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 Sodiumlightbaby
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "main.h"
+#include "oric/aud.h"
+#include "emu2149/emu2149.h"
+#include "sys/dvi_audio.h"
+#include "sys/mem.h"
+#include "pico/stdlib.h"
+#include "hardware/gpio.h"
+#include <string.h>
+#include <stdio.h>
+
+#define VIA_DRA xram[0x0303]
+#define VIA_PCR xram[0x030c]
+//Assuming only the non-handshake ORA version is used for AY access. Could be wrong
+#define VIA_ORA xram[0x030F]
+
+//Static allocation instead of using PSG_new
+PSG psg;
+audio_sample_t psg_sample;
+
+void aud_init(void){
+    PSG_setClock(&psg, 1000000/2);
+    PSG_setRate(&psg, DVI_AUDIO_FS);
+    PSG_setVolumeMode(&psg, 2); // AY style
+    PSG_setQuality(&psg, 0);
+    PSG_setMask(&psg, 0x00);
+    PSG_reset(&psg);
+    dvi_audio_set_sample_source(&psg_sample);
+}
+
+void aud_task(void){
+    static uint32_t ay_addr;
+    //TODO This is not good buffer filling. Needs rework.
+    if(!dvi_audio_buf_is_full()){
+        uint16_t sample = PSG_calc(&psg);
+        psg_sample.left = sample;
+        psg_sample.right = sample;
+    }
+
+    //CA2 -> BC1
+    //CB2 -> BDIR
+    //VIA CA2/CB2: C = 0, E = 1
+    //(BDIR,BC1) (1,0)=write (1,1)=latch address
+    uint8_t pcr = VIA_PCR; 
+    if((pcr & 0xEE) == 0xEE){
+        ay_addr = VIA_ORA & VIA_DRA;
+    }
+    if((pcr & 0xEE) == 0xEC){
+        PSG_writeReg(&psg, ay_addr, VIA_ORA & VIA_DRA);
+    }
+   
+}
+
+void aud_print_status(void){
+
+}

--- a/src/firmware/oric/aud.h
+++ b/src/firmware/oric/aud.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026 Sodiumlightbaby
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _AUD_H_
+#define _AUD_H_
+
+void aud_init(void);
+void aud_task(void);
+
+void aud_print_status(void);
+ 
+#endif /* _AUD_H_ */

--- a/src/firmware/oric/aud.h
+++ b/src/firmware/oric/aud.h
@@ -10,6 +10,8 @@
 void aud_init(void);
 void aud_task(void);
 
+void aud_tick(void);
+
 void aud_print_status(void);
  
 #endif /* _AUD_H_ */

--- a/src/firmware/oric/ula.c
+++ b/src/firmware/oric/ula.c
@@ -6,6 +6,7 @@
 
 #include "main.h"
 //#include "sys/ria.h"
+#include "oric/aud.h"
 #include "oric/ula.h"
 #include "oric/ula_dvi.h"
 #include "oric/oric_font.h"
@@ -361,6 +362,7 @@ void core1_loop(void){
                 }   
             }
         }
+    aud_tick();
     }
 }
 

--- a/src/firmware/sys/cfg.c
+++ b/src/firmware/sys/cfg.c
@@ -20,7 +20,8 @@
 // +P8000      | PHI2
 // +C0         | Caps
 // +S1         | Splash screen enable
-// +D0         | DVI display type
+// +D0         | DVI display mode
+// +A1         | DVI audio enable
 // +M0         | Mode (e.g. VIC PAL/NTSC for PIVIC)
 // BASIC       | Boot ROM - Must be last
 
@@ -31,6 +32,7 @@ static uint32_t cfg_phi2_khz;
 static uint8_t cfg_caps;
 static uint8_t cfg_splash = 1;
 static uint8_t cfg_dvi_mode = 0;
+static uint8_t cfg_dvi_audio = 1;
 static uint8_t cfg_mode = 1;
 
 // Optional string can replace boot string
@@ -69,6 +71,7 @@ static void cfg_save_with_boot_opt(char *opt_str)
                                "+C%d\n"
                                "+S%d\n"
                                "+D%d\n"
+                               "+A%d\n"
                                "+M%d\n"
                                "%s",
                                CFG_VERSION,
@@ -76,6 +79,7 @@ static void cfg_save_with_boot_opt(char *opt_str)
                                cfg_caps,
                                cfg_splash,
                                cfg_dvi_mode,
+                               cfg_dvi_audio,
                                cfg_mode,
                                opt_str);
         if (lfsresult < 0)
@@ -126,6 +130,9 @@ static void cfg_load_with_boot_opt(bool boot_only)
                 break;
             case 'D':
                 cfg_dvi_mode = val;
+                break;
+            case 'A':
+                cfg_dvi_audio = val;
                 break;
             case 'M':
                 cfg_mode = val;
@@ -220,6 +227,20 @@ bool cfg_set_dvi(uint8_t mode)
 uint8_t cfg_get_dvi(void)
 {
     return cfg_dvi_mode;
+}
+
+bool cfg_set_dvi_audio(uint8_t enable)
+{
+    if(cfg_dvi_audio != enable){
+        cfg_dvi_audio = enable;
+        cfg_save_with_boot_opt(NULL);
+    }
+    return true;
+}
+
+uint8_t cfg_get_dvi_audio(void)
+{
+    return cfg_dvi_audio;
 }
 
 bool cfg_set_mode(uint8_t mode){

--- a/src/firmware/sys/cfg.h
+++ b/src/firmware/sys/cfg.h
@@ -28,6 +28,8 @@ bool cfg_set_splash(uint8_t enable);
 uint8_t cfg_get_splash(void);
 bool cfg_set_dvi(uint8_t disp);
 uint8_t cfg_get_dvi(void);
+bool cfg_set_dvi_audio(uint8_t enable);
+uint8_t cfg_get_dvi_audio(void);
 bool cfg_set_mode(uint8_t mode);
 uint8_t cfg_get_mode(void);
 

--- a/src/firmware/sys/dvi.c
+++ b/src/firmware/sys/dvi.c
@@ -8,11 +8,13 @@
 
 /*
     Using dvi_out_hstx_encoder from pico-examples as starting point, fitted in an RP6502 like display system 
+    Integrating extensions from filliperama86
 */
 
 #include "main.h"
 #include "str.h"
 #include "sys/dvi.h"
+#include "sys/dvi_audio.h"
 #include "sys/mem.h"
 #include "hardware/clocks.h"
 #include "hardware/dma.h"
@@ -24,13 +26,14 @@
 #include "hardware/structs/sio.h"
 #include "pico/multicore.h"
 #include "pico/sem.h"
+#include "pico_hdmi/hstx_packet.h"
 #include <stdio.h>
 #include <string.h>
 
 volatile uint8_t dvi_framebuf[DVI_FB_HEIGHT][DVI_FB_WIDTH];
 
 //System specific configs are defined in their respective display subsystems
-dvi_modeline_t default_mode = {
+dvi_modeline_t local_mode = {
     .pixel_format = dvi_4_rgb332,
     .scale_x = 3,
     .scale_y = 2,
@@ -46,7 +49,10 @@ dvi_modeline_t default_mode = {
     .v_active_lines = 480,
     .sync_polarity = vneg_hneg,
 };
-dvi_modeline_t *dvi_mode = &default_mode;
+dvi_modeline_t *dvi_mode = &local_mode;
+dvi_modeline_t *next_dvi_mode;
+static bool switch_dvi_mode = false;
+
 int32_t fb_mode_offset;
 uint32_t fb_mode_transfers;
 
@@ -62,6 +68,12 @@ uint32_t fb_mode_transfers;
 #define SYNC_V0_H1 (TMDS_CTRL_01 | (TMDS_CTRL_00 << 10) | (TMDS_CTRL_00 << 20))
 #define SYNC_V1_H0 (TMDS_CTRL_10 | (TMDS_CTRL_00 << 10) | (TMDS_CTRL_00 << 20))
 #define SYNC_V1_H1 (TMDS_CTRL_11 | (TMDS_CTRL_00 << 10) | (TMDS_CTRL_00 << 20))
+
+#define PREAMBLE ((TMDS_CTRL_01 << 10) | (TMDS_CTRL_01 << 20))
+
+#define VIDEO_PREAMBLE ((TMDS_CTRL_01 << 10) | (TMDS_CTRL_00 << 20))
+
+#define VIDEO_GUARD_BAND (0x2CCu | (0x133u << 10) | (0x2CCu << 20))
 
 // #define MODE_H_SYNC_POLARITY 0
 // #define MODE_H_FRONT_PORCH   16
@@ -90,6 +102,9 @@ uint32_t fb_mode_transfers;
 #define HSTX_CMD_TMDS_REPEAT (0x3u << 12)
 #define HSTX_CMD_NOP         (0xfu << 12)
 
+#define W_VIDEO_PREAMBLE 8
+#define W_VIDEO_GUARD_BAND 2
+
 // ----------------------------------------------------------------------------
 // HSTX command lists
 
@@ -97,12 +112,28 @@ uint32_t fb_mode_transfers;
 // pingponging and tripping up the IRQs.
 
 static uint32_t vblank_line_vsync_off[7];
+static uint32_t vblank_line_vsync_off_audio[46];
 static uint32_t vblank_line_vsync_on[7];
+static uint32_t vblank_line_vsync_on_audio_info[46];
+static uint32_t vblank_line_vsync_on_avi_info[46];
+static uint32_t vblank_line_vsync_on_acr_info[46];
+static uint32_t vblank_line_vsync_off_acr_info[46];
 static uint32_t vactive_line[9];
+static uint32_t vactive_line_audio[50];
 static uint32_t vborder_line[10];
+static uint32_t vborder_line_audio[51];
+static uint32_t *audio_di_active;
+static uint32_t *audio_di_border;
+static uint32_t *audio_di_blank;
+static uint32_t *acr_di_active;
+static uint32_t acr_line_incr;
+static uint32_t acr_cts;
+
+#define HSTX_SET_LANE0(lane21, lane0) ((lane21 & 0x3FFFFC00) | (lane0 & 0x000003FF))
 
 void dvi_build_hstx_lists(dvi_modeline_t *mode){
-    uint32_t* p;
+    uint32_t *p;
+    uint32_t *di_words;
     uint32_t sync_von_hon, sync_von_hof, sync_vof_hon, sync_vof_hof;
     switch(mode->sync_polarity){
         case(vneg_hneg):
@@ -139,6 +170,22 @@ void dvi_build_hstx_lists(dvi_modeline_t *mode){
     *p++ = sync_vof_hof;
     *p++ = HSTX_CMD_NOP;
 
+    p = &vblank_line_vsync_off_audio[0];
+    *p++ = HSTX_CMD_RAW_REPEAT | mode->h_front_porch;
+    *p++ = sync_vof_hof;
+    *p++ = HSTX_CMD_RAW_REPEAT | mode->h_sync_width;
+    *p++ = sync_vof_hon;
+    *p++ = HSTX_CMD_RAW_REPEAT | W_PREAMBLE;
+    *p++ = HSTX_SET_LANE0(PREAMBLE, sync_vof_hof);
+    //*p++ = HSTX_CMD_NOP;
+    *p++ = HSTX_CMD_RAW | W_DATA_ISLAND;
+    audio_di_blank = p;
+    dvi_audio_pop_di(p);
+    p += W_DATA_ISLAND;
+    *p++ = HSTX_CMD_RAW_REPEAT | mode->h_back_porch + mode->h_active_pixels - W_PREAMBLE - W_DATA_ISLAND;
+    *p++ = sync_vof_hof;
+    *p++ = HSTX_CMD_NOP;
+
     p = &vblank_line_vsync_on[0];
     *p++ = HSTX_CMD_RAW_REPEAT | mode->h_front_porch;
     *p++ = sync_von_hof;
@@ -146,6 +193,75 @@ void dvi_build_hstx_lists(dvi_modeline_t *mode){
     *p++ = sync_von_hon;
     *p++ = HSTX_CMD_RAW_REPEAT | (mode->h_back_porch + mode->h_active_pixels);
     *p++ = sync_von_hof;
+    *p++ = HSTX_CMD_NOP;
+
+    hstx_packet_t infoframe;
+    hstx_packet_set_audio_infoframe(&infoframe, 32000, 2, 16);
+    p = &vblank_line_vsync_on_audio_info[0];
+    *p++ = HSTX_CMD_RAW_REPEAT | mode->h_front_porch;
+    *p++ = sync_von_hof;
+    *p++ = HSTX_CMD_RAW_REPEAT | mode->h_sync_width;
+    *p++ = sync_von_hon;
+    *p++ = HSTX_CMD_RAW_REPEAT | W_PREAMBLE;
+    *p++ = HSTX_SET_LANE0(PREAMBLE, sync_von_hof);
+    //*p++ = HSTX_CMD_NOP;
+    *p++ = HSTX_CMD_RAW | W_DATA_ISLAND;
+    hstx_encode_data_island((hstx_data_island_t*)p, &infoframe, true, false);
+    p += W_DATA_ISLAND;
+    *p++ = HSTX_CMD_RAW_REPEAT | mode->h_back_porch + mode->h_active_pixels - W_PREAMBLE - W_DATA_ISLAND;
+    *p++ = sync_von_hof;
+    *p++ = HSTX_CMD_NOP;
+
+    hstx_packet_set_avi_infoframe(&infoframe, 1, 0);
+    p = &vblank_line_vsync_on_avi_info[0];
+    *p++ = HSTX_CMD_RAW_REPEAT | mode->h_front_porch;
+    *p++ = sync_von_hof;
+    *p++ = HSTX_CMD_RAW_REPEAT | mode->h_sync_width;
+    *p++ = sync_von_hon;
+    *p++ = HSTX_CMD_RAW_REPEAT | W_PREAMBLE;
+    *p++ = HSTX_SET_LANE0(PREAMBLE, sync_von_hof);
+    //*p++ = HSTX_CMD_NOP;
+    *p++ = HSTX_CMD_RAW | W_DATA_ISLAND;
+    hstx_encode_data_island((hstx_data_island_t*)p, &infoframe, true, false);
+    p += W_DATA_ISLAND;
+    *p++ = HSTX_CMD_RAW_REPEAT | mode->h_back_porch + mode->h_active_pixels - W_PREAMBLE - W_DATA_ISLAND;
+    *p++ = sync_von_hof;
+    *p++ = HSTX_CMD_NOP;
+
+    uint32_t pixel_clk = clock_get_hz(clk_sys) / ( 5 * mode->hstx_div );
+    acr_cts = (uint32_t)(((uint64_t)pixel_clk * 4096) / (128ULL * 32000)); //N=4096 for 32kHz
+    acr_line_incr = pixel_clk / ((mode->h_active_pixels + mode->h_front_porch + mode->h_sync_width + mode->h_back_porch) * ((128*32000)/4096));
+
+    hstx_packet_set_acr(&infoframe, 4096, acr_cts);
+    p = &vblank_line_vsync_on_acr_info[0];
+    *p++ = HSTX_CMD_RAW_REPEAT | mode->h_front_porch;
+    *p++ = sync_von_hof;
+    *p++ = HSTX_CMD_RAW_REPEAT | mode->h_sync_width;
+    *p++ = sync_von_hon;
+    *p++ = HSTX_CMD_RAW_REPEAT | W_PREAMBLE;
+    *p++ = HSTX_SET_LANE0(PREAMBLE, sync_von_hof);
+    //*p++ = HSTX_CMD_NOP;
+    *p++ = HSTX_CMD_RAW | W_DATA_ISLAND;
+    hstx_encode_data_island((hstx_data_island_t*)p, &infoframe, true, false);
+    p += W_DATA_ISLAND;
+    *p++ = HSTX_CMD_RAW_REPEAT | mode->h_back_porch + mode->h_active_pixels - W_PREAMBLE - W_DATA_ISLAND;
+    *p++ = sync_von_hof;
+    *p++ = HSTX_CMD_NOP;
+
+    p = &vblank_line_vsync_off_acr_info[0];
+    *p++ = HSTX_CMD_RAW_REPEAT | mode->h_front_porch;
+    *p++ = sync_vof_hof;
+    *p++ = HSTX_CMD_RAW_REPEAT | mode->h_sync_width;
+    *p++ = sync_vof_hon;
+    *p++ = HSTX_CMD_RAW_REPEAT | W_PREAMBLE;
+    *p++ = HSTX_SET_LANE0(PREAMBLE, sync_vof_hof);
+    //*p++ = HSTX_CMD_NOP;
+    *p++ = HSTX_CMD_RAW | W_DATA_ISLAND;
+    hstx_encode_data_island((hstx_data_island_t*)p, &infoframe, false, false);
+    acr_di_active = p;
+    p += W_DATA_ISLAND;
+    *p++ = HSTX_CMD_RAW_REPEAT | mode->h_back_porch + mode->h_active_pixels - W_PREAMBLE - W_DATA_ISLAND;
+    *p++ = sync_vof_hof;
     *p++ = HSTX_CMD_NOP;
 
     p = &vactive_line[0];
@@ -159,6 +275,29 @@ void dvi_build_hstx_lists(dvi_modeline_t *mode){
     *p++ = sync_vof_hof;
     *p++ = HSTX_CMD_TMDS       | mode->h_active_pixels;
 
+    p = &vactive_line_audio[0];
+    *p++ = HSTX_CMD_RAW_REPEAT | mode->h_front_porch;
+    *p++ = sync_vof_hof;
+    //*p++ = HSTX_CMD_NOP;
+    *p++ = HSTX_CMD_RAW_REPEAT | mode->h_sync_width;
+    *p++ = sync_vof_hon;
+    //*p++ = HSTX_CMD_NOP;
+    *p++ = HSTX_CMD_RAW_REPEAT | W_PREAMBLE;
+    *p++ = HSTX_SET_LANE0(PREAMBLE, sync_vof_hof);
+    //*p++ = HSTX_CMD_NOP;
+    *p++ = HSTX_CMD_RAW | W_DATA_ISLAND;
+    audio_di_active = p;
+    dvi_audio_pop_di(p);
+    p += W_DATA_ISLAND;
+    *p++ = HSTX_CMD_RAW_REPEAT | mode->h_back_porch - W_PREAMBLE - W_DATA_ISLAND - W_VIDEO_PREAMBLE - W_VIDEO_GUARD_BAND;
+    *p++ = sync_vof_hof;
+    *p++ = HSTX_CMD_RAW_REPEAT | W_VIDEO_PREAMBLE;
+    *p++ = HSTX_SET_LANE0(VIDEO_PREAMBLE, sync_vof_hof);
+    //*p++ = HSTX_CMD_NOP;
+    *p++ = HSTX_CMD_RAW_REPEAT | W_VIDEO_GUARD_BAND;
+    *p++ = VIDEO_GUARD_BAND;
+    *p++ = HSTX_CMD_TMDS       | mode->h_active_pixels;
+
     p = &vborder_line[0];
     *p++ = HSTX_CMD_RAW_REPEAT | mode->h_front_porch;
     *p++ = sync_vof_hof;
@@ -170,12 +309,39 @@ void dvi_build_hstx_lists(dvi_modeline_t *mode){
     *p++ = sync_vof_hof;
     *p++ = HSTX_CMD_TMDS_REPEAT| mode->h_active_pixels;
     *p++ = 0x00000000; //black border
+
+    p = &vborder_line_audio[0];
+    *p++ = HSTX_CMD_RAW_REPEAT | mode->h_front_porch;
+    *p++ = sync_vof_hof;
+    //*p++ = HSTX_CMD_NOP;
+    *p++ = HSTX_CMD_RAW_REPEAT | mode->h_sync_width;
+    *p++ = sync_vof_hon;
+    //*p++ = HSTX_CMD_NOP;
+    *p++ = HSTX_CMD_RAW_REPEAT | W_PREAMBLE;
+    *p++ = HSTX_SET_LANE0(PREAMBLE, sync_vof_hof);
+    //*p++ = HSTX_CMD_NOP;
+    *p++ = HSTX_CMD_RAW | W_DATA_ISLAND;
+    audio_di_border = p;
+    dvi_audio_pop_di(p);
+    p += W_DATA_ISLAND;
+    *p++ = HSTX_CMD_RAW_REPEAT | mode->h_back_porch - W_PREAMBLE - W_DATA_ISLAND - W_VIDEO_PREAMBLE - W_VIDEO_GUARD_BAND;
+    *p++ = sync_vof_hof;
+    *p++ = HSTX_CMD_RAW_REPEAT | W_VIDEO_PREAMBLE;
+    *p++ = HSTX_SET_LANE0(VIDEO_PREAMBLE, sync_vof_hof);
+    //*p++ = HSTX_CMD_NOP;
+    *p++ = HSTX_CMD_RAW_REPEAT | W_VIDEO_GUARD_BAND;
+    *p++ = VIDEO_GUARD_BAND;
+    *p++ = HSTX_CMD_TMDS_REPEAT| mode->h_active_pixels;
+    *p++ = 0x00000000; //black border
 };
 
 // ----------------------------------------------------------------------------
 // DMA logic
 
 volatile uint32_t irq_count = 0;
+volatile uint32_t audio_count = 0;
+volatile uint32_t frame_count = 0;
+volatile uint32_t acr_count = 0;
 
 // First we ping. Then we pong. Then... we ping again.
 static bool dma_pong = false;
@@ -209,30 +375,86 @@ static void dma_irq_handler() {
     uint ch_num = dma_pong ? DMACH_PONG : DMACH_PING;
     static uintptr_t fb_ptr = (uintptr_t)&dvi_framebuf;
     static uint repeat = 0;
+    static bool send_avi = true;
+    static bool send_acr = true;
+    static bool send_aud = true;
+    static uint32_t line_count = 0;
+    static uint32_t next_acr_line = 0;
+
     dma_channel_hw_t *ch = &dma_hw->ch[ch_num];
     dma_hw->intr = 1u << ch_num;
     dma_pong = !dma_pong;
 
+    if(line_count >= next_acr_line){
+        send_acr = true;
+        next_acr_line = line_count + acr_line_incr;
+    }
+
     if (v_scanline < dvi_mode->v_front_porch) {
         hw_set_bits(&ch->al1_ctrl, DMA_SIZE_32 << DMA_CH0_CTRL_TRIG_DATA_SIZE_LSB);        
-        ch->read_addr = (uintptr_t)vblank_line_vsync_off;
-        ch->transfer_count = count_of(vblank_line_vsync_off);
+        if(false){
+            ch->read_addr = (uintptr_t)vblank_line_vsync_off_acr_info;
+            ch->transfer_count = count_of(vblank_line_vsync_off_acr_info);
+            send_acr = false;
+            acr_count++;
+        }else{
+            ch->read_addr = (uintptr_t)vblank_line_vsync_off;
+            ch->transfer_count = count_of(vblank_line_vsync_off);
+        }
     } else if (v_scanline < mode_v_sync_end) {
-       hw_set_bits(&ch->al1_ctrl, DMA_SIZE_32 << DMA_CH0_CTRL_TRIG_DATA_SIZE_LSB);        
-        ch->read_addr = (uintptr_t)vblank_line_vsync_on;
-        ch->transfer_count = count_of(vblank_line_vsync_on);
+        hw_set_bits(&ch->al1_ctrl, DMA_SIZE_32 << DMA_CH0_CTRL_TRIG_DATA_SIZE_LSB);
+        if(v_scanline == dvi_mode->v_front_porch){
+            ch->read_addr = (uintptr_t)vblank_line_vsync_on_acr_info;
+            ch->transfer_count = count_of(vblank_line_vsync_on_acr_info);
+            send_acr = false;
+            acr_count++;
+        }else if(send_avi){
+            ch->read_addr = (uintptr_t)vblank_line_vsync_on_avi_info;
+            ch->transfer_count = count_of(vblank_line_vsync_on_avi_info);
+            send_avi = false;
+        }else if(send_aud && frame_count % 2){        
+            ch->read_addr = (uintptr_t)vblank_line_vsync_on_audio_info;
+            ch->transfer_count = count_of(vblank_line_vsync_on_audio_info);
+            send_aud = false;
+        }else{
+            ch->read_addr = (uintptr_t)vblank_line_vsync_on;
+            ch->transfer_count = count_of(vblank_line_vsync_on);
+        }
     } else if (v_scanline < mode_v_blank_end) {
-        hw_set_bits(&ch->al1_ctrl, DMA_SIZE_32 << DMA_CH0_CTRL_TRIG_DATA_SIZE_LSB);        
-        ch->read_addr = (uintptr_t)vblank_line_vsync_off;
-        ch->transfer_count = count_of(vblank_line_vsync_off);
+        hw_set_bits(&ch->al1_ctrl, DMA_SIZE_32 << DMA_CH0_CTRL_TRIG_DATA_SIZE_LSB);
+        if(v_scanline % 4 == 0){
+            ch->read_addr = (uintptr_t)vblank_line_vsync_off_acr_info;
+            ch->transfer_count = count_of(vblank_line_vsync_off_acr_info);
+            send_acr = false;
+            acr_count++;
+        }else{
+            ch->read_addr = (uintptr_t)vblank_line_vsync_off;
+            ch->transfer_count = count_of(vblank_line_vsync_off);
+        }
     } else if (v_scanline < mode_v_border_top_end || v_scanline >= mode_v_fb_end) {
-        hw_set_bits(&ch->al1_ctrl, DMA_SIZE_32 << DMA_CH0_CTRL_TRIG_DATA_SIZE_LSB);        
-        ch->read_addr = (uintptr_t)vborder_line;
-        ch->transfer_count = count_of(vborder_line);
+        hw_set_bits(&ch->al1_ctrl, DMA_SIZE_32 << DMA_CH0_CTRL_TRIG_DATA_SIZE_LSB);
+        if(false){
+            memcpy((void*)audio_di_border, (void*)acr_di_active, sizeof(hstx_data_island_t));
+            send_acr = false;
+            acr_count++;
+        }else{
+            if(dvi_audio_pop_di(audio_di_border))
+                audio_count++;    
+        }   
+        ch->read_addr = (uintptr_t)vborder_line_audio;
+        ch->transfer_count = count_of(vborder_line_audio);
     } else if (!vactive_cmdlist_posted) {
-        hw_set_bits(&ch->al1_ctrl, DMA_SIZE_32 << DMA_CH0_CTRL_TRIG_DATA_SIZE_LSB);        
-        ch->read_addr = (uintptr_t)vactive_line;
-        ch->transfer_count = count_of(vactive_line);
+        hw_set_bits(&ch->al1_ctrl, DMA_SIZE_32 << DMA_CH0_CTRL_TRIG_DATA_SIZE_LSB);  
+        if(false){
+            memcpy((void*)audio_di_active, (void*)acr_di_active, sizeof(hstx_data_island_t));
+            send_acr = false;
+            acr_count++;
+        }else{
+            if(dvi_audio_pop_di(audio_di_active))
+                audio_count++;      
+        }
+        ch->read_addr = (uintptr_t)vactive_line_audio;
+        ch->transfer_count = count_of(vactive_line_audio);
         vactive_cmdlist_posted = true;
     } else {
         hw_clear_bits(&ch->al1_ctrl, 0x3 << DMA_CH0_CTRL_TRIG_DATA_SIZE_LSB);   //DMA_SIZE_8
@@ -246,9 +468,17 @@ static void dma_irq_handler() {
     }
 
     if (!vactive_cmdlist_posted) {
+        line_count++;
         if(++v_scanline >= mode_v_total_lines){
             v_scanline = 0;
             fb_ptr = mode_fb_start;
+            send_avi = true;
+            send_aud = true;
+            frame_count++;
+            if(switch_dvi_mode){
+                dvi_set_modeline(next_dvi_mode);
+                switch_dvi_mode = false;
+            }
         }
     }
 }
@@ -428,6 +658,9 @@ void dvi_print_status(void){
     printf(" HSTX stat:%08x\n", hstx_fifo_hw->stat);
     printf(" IRQ count:%08x\n", irq_count);
     printf(" fb_mode_transfers:%d\n", fb_mode_transfers);
+    printf(" audio_count_per_frame:%d / %d = %d \n", audio_count, frame_count, audio_count/frame_count);
+    printf(" acr_count_per_frame:%d / %d = %d \n", acr_count, frame_count, acr_count/frame_count);
+    printf(" audio acr:%d %d\n", acr_cts, acr_line_incr);
     dvi_print_modeline(dvi_mode);
 }
 
@@ -483,20 +716,30 @@ void dvi_mon_modeline(const char *args, size_t len){
             parse_polarity(&args, &len, &hvpolarity) &&
             parse_end(args, len))
        {
-            dvi_mode->h_active_pixels = hactive;
-            dvi_mode->v_active_lines = vactive;
+            local_mode.h_active_pixels = hactive;
+            local_mode.v_active_lines = vactive;
 
-            dvi_mode->h_front_porch = hsync_start - hactive;
-            dvi_mode->h_sync_width = hsync_end - hsync_start;
-            dvi_mode->h_back_porch = htotal - hsync_end;
+            local_mode.h_front_porch = hsync_start - hactive;
+            local_mode.h_sync_width = hsync_end - hsync_start;
+            local_mode.h_back_porch = htotal - hsync_end;
 
-            dvi_mode->v_front_porch = vsync_start - vactive;
-            dvi_mode->v_sync_width = vsync_end - vsync_start;
-            dvi_mode->v_back_porch = vtotal - vsync_end;
+            local_mode.v_front_porch = vsync_start - vactive;
+            local_mode.v_sync_width = vsync_end - vsync_start;
+            local_mode.v_back_porch = vtotal - vsync_end;
 
-            dvi_mode->sync_polarity = hvpolarity;
-            dvi_print_modeline(dvi_mode);
-            dvi_set_modeline(dvi_mode);
+            local_mode.sync_polarity = hvpolarity;
+
+            //Take non modeline parameters from current active mode
+            //TODO auto calculate?
+            local_mode.hstx_div = dvi_mode->hstx_div;
+            local_mode.offset_x = dvi_mode->offset_x;
+            local_mode.offset_y = dvi_mode->offset_y;
+            local_mode.scale_x = dvi_mode->scale_x;
+            local_mode.scale_y = dvi_mode->scale_y;
+
+            dvi_print_modeline(&local_mode);
+            next_dvi_mode = &local_mode;
+            switch_dvi_mode = true;
         }else{
             printf("?invalid argument\n");
             return;

--- a/src/firmware/sys/dvi.c
+++ b/src/firmware/sys/dvi.c
@@ -13,6 +13,7 @@
 
 #include "main.h"
 #include "str.h"
+#include "sys/cfg.h"
 #include "sys/dvi.h"
 #include "sys/dvi_audio.h"
 #include "sys/mem.h"
@@ -135,6 +136,8 @@ void dvi_build_hstx_lists(dvi_modeline_t *mode){
     uint32_t *p;
     uint32_t *di_words;
     uint32_t sync_von_hon, sync_von_hof, sync_vof_hon, sync_vof_hof;
+    bool vpol, hpol;
+    dvi_get_modeline_polarity(&vpol,&hpol);
     switch(mode->sync_polarity){
         case(vneg_hneg):
             sync_von_hon = SYNC_V0_H0;
@@ -196,7 +199,7 @@ void dvi_build_hstx_lists(dvi_modeline_t *mode){
     *p++ = HSTX_CMD_NOP;
 
     hstx_packet_t infoframe;
-    hstx_packet_set_audio_infoframe(&infoframe, 32000, 2, 16);
+    hstx_packet_set_audio_infoframe(&infoframe, DVI_AUDIO_FS, 2, 16);
     p = &vblank_line_vsync_on_audio_info[0];
     *p++ = HSTX_CMD_RAW_REPEAT | mode->h_front_porch;
     *p++ = sync_von_hof;
@@ -206,7 +209,7 @@ void dvi_build_hstx_lists(dvi_modeline_t *mode){
     *p++ = HSTX_SET_LANE0(PREAMBLE, sync_von_hof);
     //*p++ = HSTX_CMD_NOP;
     *p++ = HSTX_CMD_RAW | W_DATA_ISLAND;
-    hstx_encode_data_island((hstx_data_island_t*)p, &infoframe, true, false);
+    hstx_encode_data_island((hstx_data_island_t*)p, &infoframe, !vpol, hpol);
     p += W_DATA_ISLAND;
     *p++ = HSTX_CMD_RAW_REPEAT | mode->h_back_porch + mode->h_active_pixels - W_PREAMBLE - W_DATA_ISLAND;
     *p++ = sync_von_hof;
@@ -222,17 +225,16 @@ void dvi_build_hstx_lists(dvi_modeline_t *mode){
     *p++ = HSTX_SET_LANE0(PREAMBLE, sync_von_hof);
     //*p++ = HSTX_CMD_NOP;
     *p++ = HSTX_CMD_RAW | W_DATA_ISLAND;
-    hstx_encode_data_island((hstx_data_island_t*)p, &infoframe, true, false);
+    hstx_encode_data_island((hstx_data_island_t*)p, &infoframe, !vpol, hpol);
     p += W_DATA_ISLAND;
     *p++ = HSTX_CMD_RAW_REPEAT | mode->h_back_porch + mode->h_active_pixels - W_PREAMBLE - W_DATA_ISLAND;
     *p++ = sync_von_hof;
     *p++ = HSTX_CMD_NOP;
 
     uint32_t pixel_clk = clock_get_hz(clk_sys) / ( 5 * mode->hstx_div );
-    acr_cts = (uint32_t)(((uint64_t)pixel_clk * 4096) / (128ULL * 32000)); //N=4096 for 32kHz
-    acr_line_incr = pixel_clk / ((mode->h_active_pixels + mode->h_front_porch + mode->h_sync_width + mode->h_back_porch) * ((128*32000)/4096));
-
-    hstx_packet_set_acr(&infoframe, 4096, acr_cts);
+    acr_cts = (uint32_t)((uint64_t)pixel_clk * DVI_AUDIO_ACR_N / (128ULL * DVI_AUDIO_FS));
+    
+    hstx_packet_set_acr(&infoframe, DVI_AUDIO_ACR_N, acr_cts);
     p = &vblank_line_vsync_on_acr_info[0];
     *p++ = HSTX_CMD_RAW_REPEAT | mode->h_front_porch;
     *p++ = sync_von_hof;
@@ -242,7 +244,7 @@ void dvi_build_hstx_lists(dvi_modeline_t *mode){
     *p++ = HSTX_SET_LANE0(PREAMBLE, sync_von_hof);
     //*p++ = HSTX_CMD_NOP;
     *p++ = HSTX_CMD_RAW | W_DATA_ISLAND;
-    hstx_encode_data_island((hstx_data_island_t*)p, &infoframe, true, false);
+    hstx_encode_data_island((hstx_data_island_t*)p, &infoframe, !vpol, hpol);
     p += W_DATA_ISLAND;
     *p++ = HSTX_CMD_RAW_REPEAT | mode->h_back_porch + mode->h_active_pixels - W_PREAMBLE - W_DATA_ISLAND;
     *p++ = sync_von_hof;
@@ -257,7 +259,7 @@ void dvi_build_hstx_lists(dvi_modeline_t *mode){
     *p++ = HSTX_SET_LANE0(PREAMBLE, sync_vof_hof);
     //*p++ = HSTX_CMD_NOP;
     *p++ = HSTX_CMD_RAW | W_DATA_ISLAND;
-    hstx_encode_data_island((hstx_data_island_t*)p, &infoframe, false, false);
+    hstx_encode_data_island((hstx_data_island_t*)p, &infoframe, vpol, hpol);
     acr_di_active = p;
     p += W_DATA_ISLAND;
     *p++ = HSTX_CMD_RAW_REPEAT | mode->h_back_porch + mode->h_active_pixels - W_PREAMBLE - W_DATA_ISLAND;
@@ -364,7 +366,9 @@ static uint mode_v_sync_end;
 static uint mode_v_blank_end;
 static uint mode_v_border_top_end;
 static uint mode_v_fb_end;
+static uint mode_v_front_porch;
 static uintptr_t mode_fb_start;
+static bool dvi_audio_enabled;
 
 static void dma_irq_handler() {
 
@@ -375,44 +379,88 @@ static void dma_irq_handler() {
     uint ch_num = dma_pong ? DMACH_PONG : DMACH_PING;
     static uintptr_t fb_ptr = (uintptr_t)&dvi_framebuf;
     static uint repeat = 0;
-    static bool send_avi = true;
-    static bool send_acr = true;
-    static bool send_aud = true;
     static uint32_t line_count = 0;
-    static uint32_t next_acr_line = 0;
 
     dma_channel_hw_t *ch = &dma_hw->ch[ch_num];
     dma_hw->intr = 1u << ch_num;
     dma_pong = !dma_pong;
 
-    if(line_count >= next_acr_line){
-        send_acr = true;
-        next_acr_line = line_count + acr_line_incr;
-    }
-
     if (v_scanline < dvi_mode->v_front_porch) {
         hw_set_bits(&ch->al1_ctrl, DMA_SIZE_32 << DMA_CH0_CTRL_TRIG_DATA_SIZE_LSB);        
-        if(false){
-            ch->read_addr = (uintptr_t)vblank_line_vsync_off_acr_info;
-            ch->transfer_count = count_of(vblank_line_vsync_off_acr_info);
-            send_acr = false;
-            acr_count++;
-        }else{
-            ch->read_addr = (uintptr_t)vblank_line_vsync_off;
-            ch->transfer_count = count_of(vblank_line_vsync_off);
-        }
+        ch->read_addr = (uintptr_t)vblank_line_vsync_off;
+        ch->transfer_count = count_of(vblank_line_vsync_off);
     } else if (v_scanline < mode_v_sync_end) {
         hw_set_bits(&ch->al1_ctrl, DMA_SIZE_32 << DMA_CH0_CTRL_TRIG_DATA_SIZE_LSB);
-        if(v_scanline == dvi_mode->v_front_porch){
+        ch->read_addr = (uintptr_t)vblank_line_vsync_on;
+        ch->transfer_count = count_of(vblank_line_vsync_on);
+    } else if (v_scanline < mode_v_blank_end) {
+        hw_set_bits(&ch->al1_ctrl, DMA_SIZE_32 << DMA_CH0_CTRL_TRIG_DATA_SIZE_LSB);
+        ch->read_addr = (uintptr_t)vblank_line_vsync_off;
+        ch->transfer_count = count_of(vblank_line_vsync_off);
+    } else if (v_scanline < mode_v_border_top_end || v_scanline >= mode_v_fb_end) {
+        hw_set_bits(&ch->al1_ctrl, DMA_SIZE_32 << DMA_CH0_CTRL_TRIG_DATA_SIZE_LSB);
+        ch->read_addr = (uintptr_t)vborder_line;
+        ch->transfer_count = count_of(vborder_line);
+    } else if (!vactive_cmdlist_posted) {
+        hw_set_bits(&ch->al1_ctrl, DMA_SIZE_32 << DMA_CH0_CTRL_TRIG_DATA_SIZE_LSB);  
+        ch->read_addr = (uintptr_t)vactive_line;
+        ch->transfer_count = count_of(vactive_line);
+        vactive_cmdlist_posted = true;
+    } else {
+        hw_clear_bits(&ch->al1_ctrl, 0x3 << DMA_CH0_CTRL_TRIG_DATA_SIZE_LSB);   //DMA_SIZE_8
+        ch->read_addr = fb_ptr;
+        ch->transfer_count = fb_mode_transfers;
+        vactive_cmdlist_posted = false;
+        if(++repeat >= dvi_mode->scale_y){
+            fb_ptr += DVI_FB_WIDTH;
+            repeat = 0;
+        }
+    }
+
+    if (!vactive_cmdlist_posted) {
+        line_count++;
+        if(++v_scanline >= mode_v_total_lines){
+            v_scanline = 0;
+            fb_ptr = mode_fb_start;
+            frame_count++;
+            if(switch_dvi_mode){
+                dvi_set_modeline(next_dvi_mode);
+                switch_dvi_mode = false;
+            }
+        }
+    }
+}
+
+static void __scratch_y("") dma_irq_handler_audio() {
+
+    irq_count++;
+
+    // dma_pong indicates the channel that just finished, which is the one
+    // we're about to reload.
+    uint ch_num = dma_pong ? DMACH_PONG : DMACH_PING;
+    static uintptr_t fb_ptr = (uintptr_t)&dvi_framebuf;
+    static uint repeat = 0;
+    static bool send_avi = true;
+    static bool send_aud = true;
+
+    dma_channel_hw_t *ch = &dma_hw->ch[ch_num];
+    dma_hw->intr = 1u << ch_num;
+    dma_pong = !dma_pong;
+
+    if (v_scanline < mode_v_front_porch) {
+        hw_set_bits(&ch->al1_ctrl, DMA_SIZE_32 << DMA_CH0_CTRL_TRIG_DATA_SIZE_LSB);        
+            ch->read_addr = (uintptr_t)vblank_line_vsync_off;
+            ch->transfer_count = count_of(vblank_line_vsync_off);
+    } else if (v_scanline < mode_v_sync_end) {
+        hw_set_bits(&ch->al1_ctrl, DMA_SIZE_32 << DMA_CH0_CTRL_TRIG_DATA_SIZE_LSB);
+        if(v_scanline == mode_v_front_porch){
             ch->read_addr = (uintptr_t)vblank_line_vsync_on_acr_info;
             ch->transfer_count = count_of(vblank_line_vsync_on_acr_info);
-            send_acr = false;
-            acr_count++;
         }else if(send_avi){
             ch->read_addr = (uintptr_t)vblank_line_vsync_on_avi_info;
             ch->transfer_count = count_of(vblank_line_vsync_on_avi_info);
             send_avi = false;
-        }else if(send_aud && frame_count % 2){        
+        }else if(send_aud && (frame_count % 2)){        
             ch->read_addr = (uintptr_t)vblank_line_vsync_on_audio_info;
             ch->transfer_count = count_of(vblank_line_vsync_on_audio_info);
             send_aud = false;
@@ -425,34 +473,20 @@ static void dma_irq_handler() {
         if(v_scanline % 4 == 0){
             ch->read_addr = (uintptr_t)vblank_line_vsync_off_acr_info;
             ch->transfer_count = count_of(vblank_line_vsync_off_acr_info);
-            send_acr = false;
-            acr_count++;
         }else{
             ch->read_addr = (uintptr_t)vblank_line_vsync_off;
             ch->transfer_count = count_of(vblank_line_vsync_off);
         }
     } else if (v_scanline < mode_v_border_top_end || v_scanline >= mode_v_fb_end) {
         hw_set_bits(&ch->al1_ctrl, DMA_SIZE_32 << DMA_CH0_CTRL_TRIG_DATA_SIZE_LSB);
-        if(false){
-            memcpy((void*)audio_di_border, (void*)acr_di_active, sizeof(hstx_data_island_t));
-            send_acr = false;
-            acr_count++;
-        }else{
-            if(dvi_audio_pop_di(audio_di_border))
-                audio_count++;    
-        }   
+        if(dvi_audio_pop_di(audio_di_border))
+            audio_count++;    
         ch->read_addr = (uintptr_t)vborder_line_audio;
         ch->transfer_count = count_of(vborder_line_audio);
     } else if (!vactive_cmdlist_posted) {
         hw_set_bits(&ch->al1_ctrl, DMA_SIZE_32 << DMA_CH0_CTRL_TRIG_DATA_SIZE_LSB);  
-        if(false){
-            memcpy((void*)audio_di_active, (void*)acr_di_active, sizeof(hstx_data_island_t));
-            send_acr = false;
-            acr_count++;
-        }else{
-            if(dvi_audio_pop_di(audio_di_active))
-                audio_count++;      
-        }
+        if(dvi_audio_pop_di(audio_di_active))
+            audio_count++;      
         ch->read_addr = (uintptr_t)vactive_line_audio;
         ch->transfer_count = count_of(vactive_line_audio);
         vactive_cmdlist_posted = true;
@@ -468,7 +502,6 @@ static void dma_irq_handler() {
     }
 
     if (!vactive_cmdlist_posted) {
-        line_count++;
         if(++v_scanline >= mode_v_total_lines){
             v_scanline = 0;
             fb_ptr = mode_fb_start;
@@ -488,8 +521,8 @@ void dvi_fb_clear(void){
 }
 
 void dvi_init(void){
-        // Configure HSTX's TMDS encoder for RGB332
-        hstx_ctrl_hw->expand_tmds =
+    // Configure HSTX's TMDS encoder for RGB332
+    hstx_ctrl_hw->expand_tmds =
         2  << HSTX_CTRL_EXPAND_TMDS_L2_NBITS_LSB |
         0  << HSTX_CTRL_EXPAND_TMDS_L2_ROT_LSB   |
         2  << HSTX_CTRL_EXPAND_TMDS_L1_NBITS_LSB |
@@ -533,6 +566,8 @@ void dvi_init(void){
         gpio_set_function(i, GPIO_FUNC_HSTX); // HSTX
     }
 
+    dvi_audio_enabled = cfg_get_dvi_audio() != 0;
+
     // Both channels are set up identically, to transfer a whole scanline and
     // then chain to the opposite channel. Each time a channel finishes, we
     // reconfigure the one that just finished, meanwhile the opposite channel
@@ -566,7 +601,11 @@ void dvi_init(void){
     dma_hw->ints1 = (1u << DMACH_PING) | (1u << DMACH_PONG);
     dma_hw->inte1 = (1u << DMACH_PING) | (1u << DMACH_PONG);
 
-    irq_set_exclusive_handler(DMA_IRQ_1, dma_irq_handler);
+    if(cfg_get_dvi_audio()){
+        irq_set_exclusive_handler(DMA_IRQ_1, dma_irq_handler_audio);
+    }else{
+        irq_set_exclusive_handler(DMA_IRQ_1, dma_irq_handler);
+    }
     irq_set_enabled(DMA_IRQ_1, true);
 
     bus_ctrl_hw->priority = BUSCTRL_BUS_PRIORITY_DMA_W_BITS | BUSCTRL_BUS_PRIORITY_DMA_R_BITS;
@@ -635,6 +674,7 @@ void dvi_set_modeline(dvi_modeline_t *ml){
     mode_v_border_top_end = (dvi_mode->offset_y > 0) ? 0 : (mode_v_blank_end - (dvi_mode->offset_y * dvi_mode->scale_y));
     mode_v_fb_end = mode_v_blank_end + (DVI_FB_HEIGHT * dvi_mode->scale_y) - dvi_mode->offset_y;
     mode_fb_start = (uintptr_t)&(dvi_framebuf[(dvi_mode->offset_y > 0 ) ? dvi_mode->offset_y : 0][dvi_mode->offset_x]);
+    mode_v_front_porch = dvi_mode->v_front_porch;
     if(dvi_mode->offset_x < 0){
         mode_v_border_top_end += 1;
         mode_fb_start += DVI_FB_WIDTH;
@@ -652,6 +692,12 @@ void dvi_print_modeline(dvi_modeline_t *ml){
     );
 }
 
+void dvi_get_modeline_polarity(bool *vsync, bool *hsync){
+    *vsync = dvi_mode->sync_polarity == vpos_hneg || dvi_mode->sync_polarity == vpos_hpos; 
+    *hsync = dvi_mode->sync_polarity == vneg_hpos || dvi_mode->sync_polarity == vpos_hpos; 
+}
+
+
 void dvi_print_status(void){
     printf("DVI status\n PING:%08x\n PONG:%08x\n", dma_hw->ch[DMACH_PING].al1_ctrl, dma_hw->ch[DMACH_PONG].al1_ctrl);
     printf(" HSTX clock:%ld\r\n", clock_get_hz(clk_hstx));
@@ -662,6 +708,7 @@ void dvi_print_status(void){
     printf(" acr_count_per_frame:%d / %d = %d \n", acr_count, frame_count, acr_count/frame_count);
     printf(" audio acr:%d %d\n", acr_cts, acr_line_incr);
     dvi_print_modeline(dvi_mode);
+    dvi_audio_print_status();
 }
 
 bool parse_polarity(const char **args, size_t *len, dvi_sync_polarity_t *polarity)

--- a/src/firmware/sys/dvi.c
+++ b/src/firmware/sys/dvi.c
@@ -119,7 +119,7 @@ static uint32_t vblank_line_vsync_on_audio_info[46];
 static uint32_t vblank_line_vsync_on_avi_info[46];
 static uint32_t vblank_line_vsync_on_acr_info[46];
 static uint32_t vblank_line_vsync_off_acr_info[46];
-static uint32_t vactive_line[9];
+static uint32_t vactive_line[10];
 static uint32_t vactive_line_audio[50];
 static uint32_t vborder_line[10];
 static uint32_t vborder_line_audio[51];
@@ -233,6 +233,7 @@ void dvi_build_hstx_lists(dvi_modeline_t *mode){
 
     uint32_t pixel_clk = clock_get_hz(clk_sys) / ( 5 * mode->hstx_div );
     acr_cts = (uint32_t)((uint64_t)pixel_clk * DVI_AUDIO_ACR_N / (128ULL * DVI_AUDIO_FS));
+    acr_line_incr = acr_cts / (mode->h_active_pixels + mode->h_front_porch + mode->h_sync_width + mode->h_back_porch);
     
     hstx_packet_set_acr(&infoframe, DVI_AUDIO_ACR_N, acr_cts);
     p = &vblank_line_vsync_on_acr_info[0];
@@ -275,6 +276,7 @@ void dvi_build_hstx_lists(dvi_modeline_t *mode){
     *p++ = HSTX_CMD_NOP;
     *p++ = HSTX_CMD_RAW_REPEAT | mode->h_back_porch;
     *p++ = sync_vof_hof;
+    *p++ = HSTX_CMD_NOP;
     *p++ = HSTX_CMD_TMDS       | mode->h_active_pixels;
 
     p = &vactive_line_audio[0];
@@ -385,7 +387,16 @@ static void dma_irq_handler() {
     dma_hw->intr = 1u << ch_num;
     dma_pong = !dma_pong;
 
-    if (v_scanline < dvi_mode->v_front_porch) {
+    if (vactive_cmdlist_posted){
+        hw_clear_bits(&ch->al1_ctrl, 0x3 << DMA_CH0_CTRL_TRIG_DATA_SIZE_LSB);   //DMA_SIZE_8
+        ch->read_addr = fb_ptr;
+        ch->transfer_count = fb_mode_transfers;
+        vactive_cmdlist_posted = false;
+        if(++repeat >= dvi_mode->scale_y){
+            fb_ptr += DVI_FB_WIDTH;
+            repeat = 0;
+        }
+    } else if (v_scanline < dvi_mode->v_front_porch) {
         hw_set_bits(&ch->al1_ctrl, DMA_SIZE_32 << DMA_CH0_CTRL_TRIG_DATA_SIZE_LSB);        
         ch->read_addr = (uintptr_t)vblank_line_vsync_off;
         ch->transfer_count = count_of(vblank_line_vsync_off);
@@ -401,20 +412,11 @@ static void dma_irq_handler() {
         hw_set_bits(&ch->al1_ctrl, DMA_SIZE_32 << DMA_CH0_CTRL_TRIG_DATA_SIZE_LSB);
         ch->read_addr = (uintptr_t)vborder_line;
         ch->transfer_count = count_of(vborder_line);
-    } else if (!vactive_cmdlist_posted) {
+    } else {
         hw_set_bits(&ch->al1_ctrl, DMA_SIZE_32 << DMA_CH0_CTRL_TRIG_DATA_SIZE_LSB);  
         ch->read_addr = (uintptr_t)vactive_line;
         ch->transfer_count = count_of(vactive_line);
         vactive_cmdlist_posted = true;
-    } else {
-        hw_clear_bits(&ch->al1_ctrl, 0x3 << DMA_CH0_CTRL_TRIG_DATA_SIZE_LSB);   //DMA_SIZE_8
-        ch->read_addr = fb_ptr;
-        ch->transfer_count = fb_mode_transfers;
-        vactive_cmdlist_posted = false;
-        if(++repeat >= dvi_mode->scale_y){
-            fb_ptr += DVI_FB_WIDTH;
-            repeat = 0;
-        }
     }
 
     if (!vactive_cmdlist_posted) {
@@ -447,7 +449,16 @@ static void __scratch_y("") dma_irq_handler_audio() {
     dma_hw->intr = 1u << ch_num;
     dma_pong = !dma_pong;
 
-    if (v_scanline < mode_v_front_porch) {
+    if (vactive_cmdlist_posted){
+        hw_clear_bits(&ch->al1_ctrl, 0x3 << DMA_CH0_CTRL_TRIG_DATA_SIZE_LSB);   //DMA_SIZE_8
+        ch->read_addr = fb_ptr;
+        ch->transfer_count = fb_mode_transfers;
+        vactive_cmdlist_posted = false;
+        if(++repeat >= dvi_mode->scale_y){
+            fb_ptr += DVI_FB_WIDTH;
+            repeat = 0;
+        }
+    } else if (v_scanline < mode_v_front_porch) {
         hw_set_bits(&ch->al1_ctrl, DMA_SIZE_32 << DMA_CH0_CTRL_TRIG_DATA_SIZE_LSB);        
             ch->read_addr = (uintptr_t)vblank_line_vsync_off;
             ch->transfer_count = count_of(vblank_line_vsync_off);
@@ -456,6 +467,7 @@ static void __scratch_y("") dma_irq_handler_audio() {
         if(v_scanline == mode_v_front_porch){
             ch->read_addr = (uintptr_t)vblank_line_vsync_on_acr_info;
             ch->transfer_count = count_of(vblank_line_vsync_on_acr_info);
+            acr_count++;
         }else if(send_avi){
             ch->read_addr = (uintptr_t)vblank_line_vsync_on_avi_info;
             ch->transfer_count = count_of(vblank_line_vsync_on_avi_info);
@@ -470,9 +482,10 @@ static void __scratch_y("") dma_irq_handler_audio() {
         }
     } else if (v_scanline < mode_v_blank_end) {
         hw_set_bits(&ch->al1_ctrl, DMA_SIZE_32 << DMA_CH0_CTRL_TRIG_DATA_SIZE_LSB);
-        if(v_scanline % 4 == 0){
+        if(v_scanline % 2 == 0){
             ch->read_addr = (uintptr_t)vblank_line_vsync_off_acr_info;
             ch->transfer_count = count_of(vblank_line_vsync_off_acr_info);
+            acr_count++;
         }else{
             ch->read_addr = (uintptr_t)vblank_line_vsync_off;
             ch->transfer_count = count_of(vblank_line_vsync_off);
@@ -486,19 +499,10 @@ static void __scratch_y("") dma_irq_handler_audio() {
     } else if (!vactive_cmdlist_posted) {
         hw_set_bits(&ch->al1_ctrl, DMA_SIZE_32 << DMA_CH0_CTRL_TRIG_DATA_SIZE_LSB);  
         if(dvi_audio_pop_di(audio_di_active))
-            audio_count++;      
+            audio_count++;
         ch->read_addr = (uintptr_t)vactive_line_audio;
         ch->transfer_count = count_of(vactive_line_audio);
         vactive_cmdlist_posted = true;
-    } else {
-        hw_clear_bits(&ch->al1_ctrl, 0x3 << DMA_CH0_CTRL_TRIG_DATA_SIZE_LSB);   //DMA_SIZE_8
-        ch->read_addr = fb_ptr;
-        ch->transfer_count = fb_mode_transfers;
-        vactive_cmdlist_posted = false;
-        if(++repeat >= dvi_mode->scale_y){
-            fb_ptr += DVI_FB_WIDTH;
-            repeat = 0;
-        }
     }
 
     if (!vactive_cmdlist_posted) {

--- a/src/firmware/sys/dvi.h
+++ b/src/firmware/sys/dvi.h
@@ -57,6 +57,7 @@ extern volatile uint8_t dvi_framebuf[DVI_FB_HEIGHT][DVI_FB_WIDTH];
 //Modes and modelines are defined and set from the primary display systems (e.g. VIC or ULA)
 void dvi_set_modeline(dvi_modeline_t *ml);
 void dvi_print_modeline(dvi_modeline_t *ml);
+void dvi_get_modeline_polarity(bool *vsync, bool *hsync);
 void dvi_init(void);
 void dvi_task(void);
 

--- a/src/firmware/sys/dvi.h
+++ b/src/firmware/sys/dvi.h
@@ -34,16 +34,16 @@ typedef struct
     dvi_pixel_format_t pixel_format;    //Only RGB332 supported for now
     uint8_t scale_x;                    //Only 2,3 or 4 supported for now
     uint8_t scale_y;                    //Only 1 or 2 supported for now
-    int8_t offset_x;                   
-    int8_t offset_y;
+    int16_t offset_x;                   
+    int16_t offset_y;
     uint8_t hstx_div;
-    uint8_t h_front_porch;
-    uint8_t h_sync_width;
-    uint8_t h_back_porch;
+    uint16_t h_front_porch;
+    uint16_t h_sync_width;
+    uint16_t h_back_porch;
     uint16_t h_active_pixels;
-    uint8_t v_front_porch;
-    uint8_t v_sync_width;
-    uint8_t v_back_porch;
+    uint16_t v_front_porch;
+    uint16_t v_sync_width;
+    uint16_t v_back_porch;
     uint16_t v_active_lines;
     dvi_sync_polarity_t sync_polarity;
 } dvi_modeline_t;

--- a/src/firmware/sys/dvi_audio.c
+++ b/src/firmware/sys/dvi_audio.c
@@ -16,7 +16,7 @@
 
 //Buffer size must be power of 2 and max 128 
 //Alignment for direct DMA use
-#define DVI_AUDIO_BUF_LEN_BITS 5
+#define DVI_AUDIO_BUF_LEN_BITS 7
 #define DVI_AUDIO_BUF_LEN (1<<DVI_AUDIO_BUF_LEN_BITS)
 #define DVI_AUDIO_BUF_SIZE_BITS (DVI_AUDIO_BUF_LEN_BITS+2)
 
@@ -116,7 +116,7 @@ void dvi_audio_init(void){
         &sample_dma,
         audio_buf,                        // dst exactly timed sample for DVI output
         source_sample,                    // src Latest sample value from source 
-        0x10000004,                       // Self triggering, report every 4 transfers
+        0x10000001,                       // Self triggering, report every transfers
         true);
 
     dma_chan_idx = dma_claim_unused_channel(true);
@@ -134,6 +134,14 @@ void dvi_audio_init(void){
         false);
 
     dvi_get_modeline_polarity(&vsync_polarity, &hsync_polarity);
+}
+
+bool dvi_audio_fs_tick(void){
+    bool tick = !!(dma_hw->intr & 1u << dvi_audio_dma_sample_chan_idx);
+    if(tick){
+        dma_hw->intr = 1u << dvi_audio_dma_sample_chan_idx;
+    }
+    return tick;
 }
 
 uint32_t dvi_audio_count=0;

--- a/src/firmware/sys/dvi_audio.c
+++ b/src/firmware/sys/dvi_audio.c
@@ -43,6 +43,10 @@ static uint8_t di_tail_idx = 0;
 
 static volatile audio_sample_t *source_sample = 0;
 
+bool dvi_audio_buf_is_full(void){
+    return (((dma_sample_chan->write_addr >> 2) % (DVI_AUDIO_BUF_LEN)) + 1) % (DVI_AUDIO_BUF_LEN-1) == tail_idx;
+}
+
 uint8_t dvi_audio_get_buflen(void){
    return (((dma_sample_chan->write_addr >> 2) % (DVI_AUDIO_BUF_LEN)) - tail_idx) % (DVI_AUDIO_BUF_LEN-1);
 }

--- a/src/firmware/sys/dvi_audio.c
+++ b/src/firmware/sys/dvi_audio.c
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 Sodiumlightbaby
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "main.h"
+#include "sys/dvi_audio.h"
+#include "pico_hdmi/hstx_packet.h"
+#include <stdio.h>
+#include <string.h>
+
+//Buffer size must be power of 2 and max 128 
+#define AUDIO_BUF_SIZE 32
+static audio_sample_t audio_buf[AUDIO_BUF_SIZE];
+static uint8_t head_idx = 0;
+static uint8_t tail_idx = 0;
+
+//Running own small DI queue
+#define DI_BUF_SIZE 8
+hstx_data_island_t di_buf[DI_BUF_SIZE];
+static uint8_t di_head_idx = 0;
+static uint8_t di_tail_idx = 0;
+
+bool dvi_audio_push_sample(uint16_t sample){
+    static uint16_t count = 0;
+    if((head_idx + 1) % AUDIO_BUF_SIZE == tail_idx){
+        return false;
+    }
+    //TODO scale sample to reasonable 16bit levels
+    audio_buf[head_idx].left = sample << 5;
+    audio_buf[head_idx].right = sample << 5;
+    count += 312;
+    head_idx = (head_idx + 1) % AUDIO_BUF_SIZE;
+    return true;
+}
+
+uint8_t dvi_audio_get_buflen(void){
+    return (head_idx - tail_idx) & (AUDIO_BUF_SIZE-1);
+}
+
+//Pop just moves the tail index. 
+bool dvi_audio_pop_samples(uint8_t count){
+    if(dvi_audio_get_buflen() < count){
+        return false;
+    }
+    tail_idx = (tail_idx + count) % AUDIO_BUF_SIZE;
+    return true;    
+}
+
+bool dvi_audio_di_buf_is_full(void){
+    return (di_head_idx + 1) % DI_BUF_SIZE == di_tail_idx;
+}
+
+//NULL pointer will skip copy. For use with direct allocation.
+bool dvi_audio_push_di(hstx_data_island_t *di){
+    if((di_head_idx + 1) % DI_BUF_SIZE == di_tail_idx){
+        return false;
+    }
+    if(di){
+        memcpy((void*)&di_buf[di_head_idx], (void*)di, sizeof(hstx_data_island_t));
+    }
+    di_head_idx = (di_head_idx + 1) % DI_BUF_SIZE;
+    return true;
+}
+
+bool dvi_audio_pop_di(uint32_t *di){
+    if(di_head_idx == di_tail_idx){
+        const uint32_t *null_di = hstx_get_null_data_island(false,false);
+        for(int i = 0; i < W_DATA_ISLAND; i++){
+            di[i] = null_di[i];
+        }
+        return false;
+    }else{
+        uint32_t *tail_di = (uint32_t*)&di_buf[di_tail_idx];
+        for(int i = 0; i < W_DATA_ISLAND; i++){
+            di[i] = tail_di[i];
+        }
+        di_tail_idx = (di_tail_idx + 1) % DI_BUF_SIZE;
+        return true;
+    }
+}
+
+void dvi_audio_init(void){
+
+}
+
+void dvi_audio_task(void){
+    hstx_packet_t packet;
+    //hstx_data_island_t* di_ptr;
+    static int audio_frame_cnt = 0;
+    while(dvi_audio_get_buflen() >= 4 && !dvi_audio_di_buf_is_full()){
+        //Assuming working on groups of 4 samples means we won't cross ring buffer end
+        audio_frame_cnt = hstx_packet_set_audio_samples(&packet,&audio_buf[tail_idx],4,audio_frame_cnt);
+        //Assuming audio DI only in non-synch hblank period. TODO: sync polarity needs to be taking into account
+        hstx_encode_data_island(&di_buf[di_head_idx],&packet,false,false);
+        dvi_audio_pop_samples(4);
+        dvi_audio_push_di(NULL);
+    }
+}

--- a/src/firmware/sys/dvi_audio.c
+++ b/src/firmware/sys/dvi_audio.c
@@ -5,96 +5,158 @@
  */
 
 #include "main.h"
+#include "sys/cfg.h"
+#include "sys/dvi.h"
 #include "sys/dvi_audio.h"
 #include "pico_hdmi/hstx_packet.h"
+#include "hardware/clocks.h"
+#include "hardware/dma.h"
 #include <stdio.h>
 #include <string.h>
 
 //Buffer size must be power of 2 and max 128 
-#define AUDIO_BUF_SIZE 32
-static audio_sample_t audio_buf[AUDIO_BUF_SIZE];
-static uint8_t head_idx = 0;
+//Alignment for direct DMA use
+#define DVI_AUDIO_BUF_LEN_BITS 5
+#define DVI_AUDIO_BUF_LEN (1<<DVI_AUDIO_BUF_LEN_BITS)
+#define DVI_AUDIO_BUF_SIZE_BITS (DVI_AUDIO_BUF_LEN_BITS+2)
+
+audio_sample_t audio_buf[DVI_AUDIO_BUF_LEN] 
+    __attribute__ ((aligned (sizeof(audio_sample_t)*DVI_AUDIO_BUF_LEN)));
+
+dma_channel_hw_t *dma_sample_chan;
+dma_channel_hw_t *dma_di_chan;
+int sample_timer;
+int dvi_audio_dma_sample_chan_idx;
 static uint8_t tail_idx = 0;
 
+bool vsync_polarity;
+bool hsync_polarity;
+
 //Running own small DI queue
-#define DI_BUF_SIZE 8
-hstx_data_island_t di_buf[DI_BUF_SIZE];
+#define DI_BUF_LEN_BITS 3
+#define DI_BUF_LEN (1<<DI_BUF_LEN_BITS)
+#define DI_BUF_SIZE_BITS (DI_BUF_LEN_BITS+2)
+
+hstx_data_island_t di_buf[DI_BUF_LEN];
 static uint8_t di_head_idx = 0;
 static uint8_t di_tail_idx = 0;
 
-bool dvi_audio_push_sample(uint16_t sample){
-    static uint16_t count = 0;
-    if((head_idx + 1) % AUDIO_BUF_SIZE == tail_idx){
-        return false;
-    }
-    //TODO scale sample to reasonable 16bit levels
-    audio_buf[head_idx].left = sample << 5;
-    audio_buf[head_idx].right = sample << 5;
-    count += 312;
-    head_idx = (head_idx + 1) % AUDIO_BUF_SIZE;
-    return true;
-}
+static volatile audio_sample_t *source_sample = 0;
 
 uint8_t dvi_audio_get_buflen(void){
-    return (head_idx - tail_idx) & (AUDIO_BUF_SIZE-1);
+   return (((dma_sample_chan->write_addr >> 2) % (DVI_AUDIO_BUF_LEN)) - tail_idx) % (DVI_AUDIO_BUF_LEN-1);
 }
 
 //Pop just moves the tail index. 
 bool dvi_audio_pop_samples(uint8_t count){
-    if(dvi_audio_get_buflen() < count){
-        return false;
-    }
-    tail_idx = (tail_idx + count) % AUDIO_BUF_SIZE;
+    tail_idx = (tail_idx + count) % (DVI_AUDIO_BUF_LEN);
     return true;    
 }
 
 bool dvi_audio_di_buf_is_full(void){
-    return (di_head_idx + 1) % DI_BUF_SIZE == di_tail_idx;
+    return (di_head_idx + 1) % (DI_BUF_LEN) == di_tail_idx;
 }
 
 //NULL pointer will skip copy. For use with direct allocation.
 bool dvi_audio_push_di(hstx_data_island_t *di){
-    if((di_head_idx + 1) % DI_BUF_SIZE == di_tail_idx){
+    if((di_head_idx + 1) % (DI_BUF_LEN) == di_tail_idx){
         return false;
     }
     if(di){
         memcpy((void*)&di_buf[di_head_idx], (void*)di, sizeof(hstx_data_island_t));
     }
-    di_head_idx = (di_head_idx + 1) % DI_BUF_SIZE;
+    di_head_idx = (di_head_idx + 1) % (DI_BUF_LEN);
     return true;
 }
 
 bool dvi_audio_pop_di(uint32_t *di){
     if(di_head_idx == di_tail_idx){
-        const uint32_t *null_di = hstx_get_null_data_island(false,false);
-        for(int i = 0; i < W_DATA_ISLAND; i++){
-            di[i] = null_di[i];
-        }
+        const uint32_t *null_di = hstx_get_null_data_island(vsync_polarity,hsync_polarity);
+        dma_di_chan->read_addr = (uint32_t)null_di;
+        dma_di_chan->al2_write_addr_trig = (uint32_t)di;
         return false;
     }else{
         uint32_t *tail_di = (uint32_t*)&di_buf[di_tail_idx];
-        for(int i = 0; i < W_DATA_ISLAND; i++){
-            di[i] = tail_di[i];
-        }
-        di_tail_idx = (di_tail_idx + 1) % DI_BUF_SIZE;
+        dma_di_chan->read_addr = (uint32_t)tail_di;
+        dma_di_chan->al2_write_addr_trig = (uint32_t)di;
+        di_tail_idx = (di_tail_idx + 1) % (DI_BUF_LEN);
         return true;
     }
 }
 
-void dvi_audio_init(void){
-
+void dvi_audio_set_sample_source(volatile audio_sample_t *src_ptr){
+    source_sample = src_ptr;
 }
 
+bool dvi_audio_enabled = false;
+
+void dvi_audio_init(void){
+    if(source_sample == NULL || cfg_get_dvi_audio() == 0)
+        return;
+
+    dvi_audio_enabled = true;
+    
+    int dma_chan_idx = dma_claim_unused_channel(true);
+    dvi_audio_dma_sample_chan_idx = dma_chan_idx;
+    dma_sample_chan = &dma_hw->ch[dma_chan_idx];
+    dma_channel_config sample_dma = dma_channel_get_default_config(dma_chan_idx);
+    sample_timer = dma_claim_unused_timer(true);
+    dma_timer_set_fraction(sample_timer, 1, clock_get_hz(clk_sys)/DVI_AUDIO_FS);    //Assumes integer divisable sys_clk to fs ratio
+    channel_config_set_dreq(&sample_dma, dma_get_timer_dreq(sample_timer));
+    channel_config_set_read_increment(&sample_dma, false);
+    channel_config_set_write_increment(&sample_dma, true);
+    channel_config_set_ring(&sample_dma, true, DVI_AUDIO_BUF_SIZE_BITS);
+    channel_config_set_transfer_data_size(&sample_dma, DMA_SIZE_32);
+    dma_channel_configure(
+        dma_chan_idx,
+        &sample_dma,
+        audio_buf,                        // dst exactly timed sample for DVI output
+        source_sample,                    // src Latest sample value from source 
+        0x10000004,                       // Self triggering, report every 4 transfers
+        true);
+
+    dma_chan_idx = dma_claim_unused_channel(true);
+    dma_di_chan = &dma_hw->ch[dma_chan_idx];
+    dma_channel_config di_dma = dma_channel_get_default_config(dma_chan_idx);
+    channel_config_set_read_increment(&di_dma, true);
+    channel_config_set_write_increment(&di_dma, true);
+    channel_config_set_transfer_data_size(&di_dma, DMA_SIZE_32);
+    dma_channel_configure(
+        dma_chan_idx,
+        &di_dma,
+        NULL,                              // dst set each time
+        &di_buf[0],                        // src set each time 
+        W_DATA_ISLAND,                     // Length of data island
+        false);
+
+    dvi_get_modeline_polarity(&vsync_polarity, &hsync_polarity);
+}
+
+uint32_t dvi_audio_count=0;
+
 void dvi_audio_task(void){
-    hstx_packet_t packet;
-    //hstx_data_island_t* di_ptr;
-    static int audio_frame_cnt = 0;
-    while(dvi_audio_get_buflen() >= 4 && !dvi_audio_di_buf_is_full()){
-        //Assuming working on groups of 4 samples means we won't cross ring buffer end
-        audio_frame_cnt = hstx_packet_set_audio_samples(&packet,&audio_buf[tail_idx],4,audio_frame_cnt);
-        //Assuming audio DI only in non-synch hblank period. TODO: sync polarity needs to be taking into account
-        hstx_encode_data_island(&di_buf[di_head_idx],&packet,false,false);
-        dvi_audio_pop_samples(4);
-        dvi_audio_push_di(NULL);
+    //SW interrupt monitoring of fs clock to not disturb DVI interrupt system
+
+        hstx_packet_t packet;
+        static int audio_frame_cnt = 0;
+        if(dvi_audio_get_buflen() >= 4 && !dvi_audio_di_buf_is_full()){
+            //Assuming working on groups of 4 samples means we won't cross ring buffer end
+            audio_frame_cnt = hstx_packet_set_audio_samples(&packet,&audio_buf[tail_idx],4,audio_frame_cnt);
+            //Assuming audio DI only in non-synch hblank period. TODO: sync polarity needs to be taking into account
+            hstx_encode_data_island(&di_buf[di_head_idx],&packet,vsync_polarity,hsync_polarity);
+            dvi_audio_pop_samples(4);
+            dvi_audio_push_di(NULL);
+            dvi_audio_count++;
     }
+}
+
+void dvi_audio_print_status(void){
+    puts("DVI audio status");
+    printf(" dvi audio:%s\n", dvi_audio_enabled ? "enabled" : "disabled");
+    printf(" source_sample addr:%08x\n", source_sample);
+    printf(" samples:%d\n packets:%d\n", dvi_audio_count<<2, dvi_audio_count);
+    printf(" audio buf level:%d addr:%08x tail:%d\n", dvi_audio_get_buflen(), audio_buf, tail_idx);
+    printf(" di buf level:%d\n", (di_head_idx - di_tail_idx) % DI_BUF_LEN);
+    printf(" dma rd:%08x wr:%08x cnt:%08x\n", dma_sample_chan->read_addr, dma_sample_chan->write_addr, dma_sample_chan->transfer_count);
+    printf(" sample %d %d\n", audio_buf[tail_idx].left, audio_buf[tail_idx].left);
 }

--- a/src/firmware/sys/dvi_audio.h
+++ b/src/firmware/sys/dvi_audio.h
@@ -17,11 +17,8 @@
 #define DVI_AUDIO_FS 48000
 #define DVI_AUDIO_ACR_N 6144
 
-extern int dvi_audio_dma_sample_chan_idx;
-
 void dvi_audio_init(void);
 void dvi_audio_task(void);
-
 
 //Sample source is a fixed location that is sampled
 //at the DVI audio frequency for digital output.
@@ -29,6 +26,8 @@ void dvi_audio_task(void);
 void dvi_audio_set_sample_source(volatile audio_sample_t *src_ptr);
 bool dvi_audio_buf_is_full(void);
 bool dvi_audio_pop_di(uint32_t *di);
+
+bool dvi_audio_fs_tick(void);
 
 void dvi_audio_print_status(void);
 

--- a/src/firmware/sys/dvi_audio.h
+++ b/src/firmware/sys/dvi_audio.h
@@ -12,10 +12,23 @@
 #include <stdint.h>
 #include "pico_hdmi/hstx_packet.h"
 
+// #define DVI_AUDIO_FS 32000
+// #define DVI_AUDIO_ACR_N 4096
+#define DVI_AUDIO_FS 48000
+#define DVI_AUDIO_ACR_N 6144
+
+extern int dvi_audio_dma_sample_chan_idx;
+
 void dvi_audio_init(void);
 void dvi_audio_task(void);
 
-bool dvi_audio_push_sample(uint16_t sample);
+
+//Sample source is a fixed location that is sampled
+//at the DVI audio frequency for digital output.
+//Must be set before dvi_audio_init() is called
+void dvi_audio_set_sample_source(volatile audio_sample_t *src_ptr);
 bool dvi_audio_pop_di(uint32_t *di);
+
+void dvi_audio_print_status(void);
 
 #endif /* _DVI_AUDIO_H_ */

--- a/src/firmware/sys/dvi_audio.h
+++ b/src/firmware/sys/dvi_audio.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 Sodiumlightbaby
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _DVI_AUDIO_H_
+#define _DVI_AUDIO_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include "pico_hdmi/hstx_packet.h"
+
+void dvi_audio_init(void);
+void dvi_audio_task(void);
+
+bool dvi_audio_push_sample(uint16_t sample);
+bool dvi_audio_pop_di(uint32_t *di);
+
+#endif /* _DVI_AUDIO_H_ */

--- a/src/firmware/sys/dvi_audio.h
+++ b/src/firmware/sys/dvi_audio.h
@@ -27,6 +27,7 @@ void dvi_audio_task(void);
 //at the DVI audio frequency for digital output.
 //Must be set before dvi_audio_init() is called
 void dvi_audio_set_sample_source(volatile audio_sample_t *src_ptr);
+bool dvi_audio_buf_is_full(void);
 bool dvi_audio_pop_di(uint32_t *di);
 
 void dvi_audio_print_status(void);

--- a/src/firmware/vic/aud.c
+++ b/src/firmware/vic/aud.c
@@ -56,15 +56,15 @@ void aud_step_noise(uint8_t reg){
     }
 }
 
+volatile audio_sample_t pwm_sample;
+//volatile audio_sample_t dvi_sample;
 
-volatile uint16_t pwm_sample;
-volatile uint16_t dvi_sample;
-
-uint8_t aud_update_pwm(uint8_t vol_reg){
-    int16_t pwm_value_signed = ( aud_val[0] + aud_val[1] + aud_val[2] + aud_val[3] ) * (vol_reg & 0x0F);
-    pwm_set_chan_level(AUDIO_PWM_SLICE, AUDIO_PWM_CH, (uint8_t)(pwm_value_signed + 32));    //DC offset required for bias of mainboard audio circuit
-    pwm_sample = pwm_value_signed;
-    return (uint8_t)(pwm_value_signed + 32);
+void aud_update_pwm(void){
+    int16_t pwm_value_signed = ( aud_val[0] + aud_val[1] + aud_val[2] + aud_val[3] ) * (VIC_CRE & 0x0F);
+    uint8_t sample = (uint8_t)(pwm_value_signed + 32);  //DC offset required for bias of mainboard audio circuit
+    pwm_set_chan_level(AUDIO_PWM_SLICE, AUDIO_PWM_CH, sample);    
+    pwm_sample.left = sample << 5;
+    pwm_sample.right = sample << 5;
 }
 
 void aud_init(void){
@@ -77,29 +77,6 @@ void aud_init(void){
     pwm_init(AUDIO_PWM_SLICE, &config, true);
     pwm_set_chan_level(AUDIO_PWM_SLICE, AUDIO_PWM_CH, 0);
     pwm_set_enabled(AUDIO_PWM_SLICE, true);
-
-    config = pwm_get_default_config();
-    pwm_config_set_wrap(&config, clock_get_hz(clk_sys)/32000);   //Make 32kHz clock
-    pwm_init(AUDIO_SAMPLE_PWM_SLICE, &config, true);
-    pwm_set_enabled(AUDIO_SAMPLE_PWM_SLICE, true);
-
-    int sample_chan = dma_claim_unused_channel(true);
-
-    dma_channel_config sample_dma = dma_channel_get_default_config(sample_chan);
-    // int sample_timer = dma_claim_unused_timer(true);
-    // dma_timer_set_fraction(sample_timer, clock_get_hz(clk_sys)/32000, 0);
-    // channel_config_set_dreq(&sample_dma, dma_get_timer_dreq(sample_timer));
-    channel_config_set_dreq(&sample_dma, pwm_get_dreq(AUDIO_SAMPLE_PWM_SLICE));
-    channel_config_set_read_increment(&sample_dma, false);
-    channel_config_set_write_increment(&sample_dma, false);
-    channel_config_set_transfer_data_size(&sample_dma, DMA_SIZE_16);
-    dma_channel_configure(
-        sample_chan,
-        &sample_dma,
-        &dvi_sample,                      // dst exactly timed sample for DVI output
-        &pwm_sample,                      // src Latest sample value from PWM
-        0xFF000000,                       // Single transfer 
-        true);
 
     // Init the three voices to zero
     for(int i=0; i < 3; i++){
@@ -124,32 +101,23 @@ void aud_init(void){
     VIC_CRC = 0x00;
     VIC_CRD = 0x00;
     VIC_CRE = 0xF;
+
+    dvi_audio_set_sample_source(&pwm_sample);
 }
 
 static int64_t last_sample_time_diff;
 static uint32_t lost_samples = 0;
 //TODO Is calculating and updating audio in normal task good enough?
+//
 void aud_task(void){
-    aud_calc_voice(0, aud_regs.ch[0]);
-    aud_calc_voice(1, aud_regs.ch[1]);
-    aud_calc_voice(2, aud_regs.ch[2]);
-    // if(multicore_doorbell_is_set_current_core(3)){
-    //     multicore_doorbell_clear_current_core(3);
     while(multicore_fifo_rvalid()){
         uint32_t upd = sio_hw->fifo_rd;
+        aud_calc_voice(0, aud_regs.ch[0]);
+        aud_calc_voice(1, aud_regs.ch[1]);
+        aud_calc_voice(2, aud_regs.ch[2]);
         if(upd & 0x08)
-        aud_step_noise(upd >> 24);
-    }
-    uint8_t sample = aud_update_pwm(VIC_CRE);
-    static absolute_time_t time_of_last_sample;
-    //SW interrupt monitoring of 32kHz clock to not disturb DVI interrupt system
-    if(pwm_hw->intr & (1u << AUDIO_SAMPLE_PWM_SLICE)){
-        pwm_clear_irq(AUDIO_SAMPLE_PWM_SLICE);
-        if(!dvi_audio_push_sample(dvi_sample)){
-            lost_samples++;
-        }
-        last_sample_time_diff = absolute_time_diff_us(time_of_last_sample, get_absolute_time());
-        time_of_last_sample = get_absolute_time();
+            aud_step_noise(upd >> 24);
+        aud_update_pwm();
     }
 }
 
@@ -161,6 +129,6 @@ void aud_print_status(void){
         );
     printf("    tck:%08x cnt:%08x upd:%01x\n", aud_ticks.all, aud_counters.all, sio_hw->doorbell_in_set);
     printf("    pwm intr:%08x\n", pwm_hw->intr);
-    printf("    last_sample_periode_us: %lld\n", last_sample_time_diff);
-    printf("    DVI lost samples: %d\n", lost_samples);
+    // printf("    last_sample_periode_us: %lld\n", last_sample_time_diff);
+    // printf("    DVI lost samples: %d\n", lost_samples);
 }

--- a/src/firmware/vic/aud.c
+++ b/src/firmware/vic/aud.c
@@ -117,7 +117,8 @@ void aud_task(void){
         aud_calc_voice(2, aud_regs.ch[2]);
         if(upd & 0x08)
             aud_step_noise(upd >> 24);
-        aud_update_pwm();
+        if(dvi_audio_fs_tick())
+            aud_update_pwm();
     }
 }
 

--- a/src/firmware/vic/aud.c
+++ b/src/firmware/vic/aud.c
@@ -7,9 +7,12 @@
 
 #include "main.h"
 #include "vic/aud.h"
+#include "sys/dvi_audio.h"
 #include "sys/mem.h"
+#include "hardware/dma.h"
 #include "hardware/gpio.h"
 #include "hardware/pwm.h"
+#include "hardware/clocks.h"
 #include "pico/multicore.h"
 #include <stdbool.h>
 #include <stdio.h>
@@ -53,9 +56,15 @@ void aud_step_noise(uint8_t reg){
     }
 }
 
-void aud_update_pwm(uint8_t vol_reg){
+
+volatile uint16_t pwm_sample;
+volatile uint16_t dvi_sample;
+
+uint8_t aud_update_pwm(uint8_t vol_reg){
     int16_t pwm_value_signed = ( aud_val[0] + aud_val[1] + aud_val[2] + aud_val[3] ) * (vol_reg & 0x0F);
     pwm_set_chan_level(AUDIO_PWM_SLICE, AUDIO_PWM_CH, (uint8_t)(pwm_value_signed + 32));    //DC offset required for bias of mainboard audio circuit
+    pwm_sample = pwm_value_signed;
+    return (uint8_t)(pwm_value_signed + 32);
 }
 
 void aud_init(void){
@@ -68,6 +77,29 @@ void aud_init(void){
     pwm_init(AUDIO_PWM_SLICE, &config, true);
     pwm_set_chan_level(AUDIO_PWM_SLICE, AUDIO_PWM_CH, 0);
     pwm_set_enabled(AUDIO_PWM_SLICE, true);
+
+    config = pwm_get_default_config();
+    pwm_config_set_wrap(&config, clock_get_hz(clk_sys)/32000);   //Make 32kHz clock
+    pwm_init(AUDIO_SAMPLE_PWM_SLICE, &config, true);
+    pwm_set_enabled(AUDIO_SAMPLE_PWM_SLICE, true);
+
+    int sample_chan = dma_claim_unused_channel(true);
+
+    dma_channel_config sample_dma = dma_channel_get_default_config(sample_chan);
+    // int sample_timer = dma_claim_unused_timer(true);
+    // dma_timer_set_fraction(sample_timer, clock_get_hz(clk_sys)/32000, 0);
+    // channel_config_set_dreq(&sample_dma, dma_get_timer_dreq(sample_timer));
+    channel_config_set_dreq(&sample_dma, pwm_get_dreq(AUDIO_SAMPLE_PWM_SLICE));
+    channel_config_set_read_increment(&sample_dma, false);
+    channel_config_set_write_increment(&sample_dma, false);
+    channel_config_set_transfer_data_size(&sample_dma, DMA_SIZE_16);
+    dma_channel_configure(
+        sample_chan,
+        &sample_dma,
+        &dvi_sample,                      // dst exactly timed sample for DVI output
+        &pwm_sample,                      // src Latest sample value from PWM
+        0xFF000000,                       // Single transfer 
+        true);
 
     // Init the three voices to zero
     for(int i=0; i < 3; i++){
@@ -94,6 +126,8 @@ void aud_init(void){
     VIC_CRE = 0xF;
 }
 
+static int64_t last_sample_time_diff;
+static uint32_t lost_samples = 0;
 //TODO Is calculating and updating audio in normal task good enough?
 void aud_task(void){
     aud_calc_voice(0, aud_regs.ch[0]);
@@ -106,7 +140,17 @@ void aud_task(void){
         if(upd & 0x08)
         aud_step_noise(upd >> 24);
     }
-    aud_update_pwm(VIC_CRE);
+    uint8_t sample = aud_update_pwm(VIC_CRE);
+    static absolute_time_t time_of_last_sample;
+    //SW interrupt monitoring of 32kHz clock to not disturb DVI interrupt system
+    if(pwm_hw->intr & (1u << AUDIO_SAMPLE_PWM_SLICE)){
+        pwm_clear_irq(AUDIO_SAMPLE_PWM_SLICE);
+        if(!dvi_audio_push_sample(dvi_sample)){
+            lost_samples++;
+        }
+        last_sample_time_diff = absolute_time_diff_us(time_of_last_sample, get_absolute_time());
+        time_of_last_sample = get_absolute_time();
+    }
 }
 
 void aud_print_status(void){
@@ -116,4 +160,7 @@ void aud_print_status(void){
             aud_lfsr
         );
     printf("    tck:%08x cnt:%08x upd:%01x\n", aud_ticks.all, aud_counters.all, sio_hw->doorbell_in_set);
+    printf("    pwm intr:%08x\n", pwm_hw->intr);
+    printf("    last_sample_periode_us: %lld\n", last_sample_time_diff);
+    printf("    DVI lost samples: %d\n", lost_samples);
 }


### PR DESCRIPTION
Add experimental support for digital audio over DVI connection. Audio quality is not final. Pure DVI monitors may not accept the signal and require this feature disabled. Enable and disable with "set audio (0|1)". Oric audio is implemented with page 3 snooping of the VIA to AY accesses and a 3rd party AY emulation library emu2149.