### PR TITLE
Add Input pins testing mode and command for the monitor

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,6 +58,7 @@ target_sources(ocula PRIVATE
     firmware/sys/lfs.c
     firmware/sys/mem.c
     firmware/sys/sys.c
+    firmware/sys/tst.c
 #    firmware/sys/vga.c
     firmware/term/color.c
     firmware/term/font.c
@@ -148,6 +149,7 @@ target_sources(pivic PRIVATE
     firmware/sys/mem.c
     firmware/sys/rev.c
     firmware/sys/sys.c
+    firmware/sys/tst.c
 #    firmware/sys/vga.c
     firmware/term/color.c
     firmware/term/font.c

--- a/src/firmware/main.c
+++ b/src/firmware/main.c
@@ -20,6 +20,7 @@
 #include "sys/lfs.h"
 #include "sys/rev.h"
 #include "sys/sys.h"
+#include "sys/tst.h"
 #include "sys/vga.h"
 #include "term/font.h"
 #include "term/term.h"
@@ -79,6 +80,7 @@ static void init(void)
 #endif
     dvi_init();
     dvi_audio_init();
+    tst_init();
 }
 
 static void task(void)
@@ -105,6 +107,7 @@ static void task(void)
     mon_task();
     //ram_task();
     dvi_audio_task();
+    tst_task();
 }
 
 void main_flush(void)

--- a/src/firmware/mon/hlp.c
+++ b/src/firmware/mon/hlp.c
@@ -20,7 +20,8 @@ static const char __in_flash("helptext") hlp_text_help[] =
     "UPLOAD file         - Write file. Binary chunks follow.\n"
     "BINARY addr len crc - Write memory. Binary data follows.\n"
     "0000 (00 00 ...)    - Read or write memory.\n"
-    "MODELINE ()()()..   - Test alternative DVI modes.";
+    "MODELINE ()()()..   - Test alternative DVI modes.\n"
+    "TEST                - Test input pins on device";
 
 static const char __in_flash("helptext") hlp_text_set[] =
     "Settings:\n"
@@ -153,6 +154,15 @@ static const char __in_flash("helptext") hlp_text_modeline[] =
     "<vsync_start> <vsync_end> <vtotal> <hpolarity><vpolarity>\n" 
     ;
 
+static const char __in_flash("helptext") hlp_text_test[] =
+    "TEST is a testing mode to check inputs on the physical PCB.\n"
+    "Normal operation is not halted but operation glitches may occure.\n"
+    "When called the device will track if an input pin has toggled\n"
+    "indicating the connection between the pin pad on the PCB and \n"
+    "microcontroller is likely good. Out of circuit a probe with serial\n"
+    "resistor temporary connected to the PHI clock output pin can be used to\n"
+    "toggle the input. Use care and only use safe probes and only on input\n"
+    "pins marked with arrow pointing in to the middle of the board figure (> <).";
 
 static const char __in_flash("helptext") hlp_text_splash[] =
     "SET SPLASH enables or disables splash screen shown before the computer\n"
@@ -246,6 +256,7 @@ static struct
     {6, "upload", hlp_text_upload},
     {6, "binary", hlp_text_binary},
     {8, "modeline", hlp_text_modeline},
+    {4, "test", hlp_text_test},
 #ifdef PIVIC
     {6, "colour", hlp_text_colour},
     {5, "color", hlp_text_colour},

--- a/src/firmware/mon/mon.c
+++ b/src/firmware/mon/mon.c
@@ -14,6 +14,7 @@
 #include "sys/dvi.h"
 #include "sys/mem.h"
 #include "sys/sys.h"
+#include "sys/tst.h"
 #include "sys/vga.h"
 #include "vic/cvbs.h"
 #include "pico/stdlib.h"
@@ -38,6 +39,7 @@ static struct
     {5, "reset", sys_mon_reset},
     {6, "binary", ram_mon_binary},
     {8, "modeline", dvi_mon_modeline},
+    {4, "test", tst_mon_test},
 #ifdef PIVIC
     {4, "tune", cvbs_mon_tune},
     {6, "colour", cvbs_mon_colour},

--- a/src/firmware/sys/tst.c
+++ b/src/firmware/sys/tst.c
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026 Sodiumlightbaby
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "main.h"
+#include "sys/tst.h"
+#include "sys/rev.h"
+#include "pico/stdlib.h"
+#include "hardware/gpio.h"
+#include <stdbool.h>
+#include <stdio.h>
+#include "str.h"
+
+static bool testing;
+
+static uint64_t toggled;
+static uint64_t prev;
+
+#define TST_PIN(bitmap,n) (bitmap & (1ull << n) ? 1 : 0) 
+
+void tst_init(void){
+    testing = false;
+    toggled = 0;
+    prev = gpio_get_all64();
+}
+
+void tst_task(void){
+    static absolute_time_t print_timer = 0;
+    if(testing){
+        toggled |= prev ^ gpio_get_all64();
+        prev = gpio_get_all64();
+        if(absolute_time_diff_us(get_absolute_time(),print_timer) < 0){
+            tst_print_status();
+            print_timer = delayed_by_ms(get_absolute_time(),100);
+        }
+    }
+}
+
+void tst_print_status(void){
+#ifdef PIVIC
+    uint8_t potx, poty;
+    switch(rev_get()){
+        case(REV_1_1):
+            potx = POTX_PIN_1_1;
+            poty = POTY_PIN_1_1;
+            break;
+        case(REV_1_2):
+            potx = POTX_PIN_1_1;
+            poty = POTY_PIN_1_1;
+            break;
+        default:
+            puts("Test print error: !Unknown hardware revision\n");
+            return;
+    }
+    printf( "\033[s\033[0;0H");
+    printf( "__________________________\n");
+    printf( "  NC 01 -   USB    40 VDD \n"
+            " CHR 02 <        - 39 XT1 \n"
+            " LUM 03 <        - 38 XT2 \n");
+    printf( " RNW 04 > %d    %d < 37 OPT \n", TST_PIN(toggled,RNW_PIN), TST_PIN(toggled,PEN_PIN));
+    printf( " D11 05 -        - 36 PHI2\n"
+            " D10 06 -        > 35 PHI1\n");
+    printf( "  D9 07 -      %d < 34 A13 \n", TST_PIN(toggled,ADDR_PIN_BASE+13));
+    printf( "  D8 08 -      %d < 33 A12 \n", TST_PIN(toggled,ADDR_PIN_BASE+12));
+    printf( "  D7 09 > %d    %d < 32 A11 \n", TST_PIN(toggled,DATA_PIN_BASE+7), TST_PIN(toggled,ADDR_PIN_BASE+11));
+    printf( "  D6 10 > %d    %d < 31 A10 \n", TST_PIN(toggled,DATA_PIN_BASE+6), TST_PIN(toggled,ADDR_PIN_BASE+10));
+    printf( "  D5 11 > %d    %d < 30 A9  \n", TST_PIN(toggled,DATA_PIN_BASE+5), TST_PIN(toggled,ADDR_PIN_BASE+9));
+    printf( "  D4 12 > %d    %d < 29 A8  \n", TST_PIN(toggled,DATA_PIN_BASE+4), TST_PIN(toggled,ADDR_PIN_BASE+8));
+    printf( "  D3 13 > %d    %d < 28 A7  \n", TST_PIN(toggled,DATA_PIN_BASE+3), TST_PIN(toggled,ADDR_PIN_BASE+7));
+    printf( "  D2 14 > %d    %d < 27 A6  \n", TST_PIN(toggled,DATA_PIN_BASE+2), TST_PIN(toggled,ADDR_PIN_BASE+6));
+    printf( "  D1 15 > %d    %d < 26 A5  \n", TST_PIN(toggled,DATA_PIN_BASE+1), TST_PIN(toggled,ADDR_PIN_BASE+5));
+    printf( "  D0 16 > %d    %d < 25 A4  \n", TST_PIN(toggled,DATA_PIN_BASE+0), TST_PIN(toggled,ADDR_PIN_BASE+4));
+    printf( "POTX 17 > %d    %d < 24 A3  \n", TST_PIN(toggled,potx), TST_PIN(toggled,ADDR_PIN_BASE+3));
+    printf( "POTY 18 > %d    %d < 23 A2  \n", TST_PIN(toggled,poty), TST_PIN(toggled,ADDR_PIN_BASE+2));
+    printf( " AUD 19 <      %d < 22 A1  \n", TST_PIN(toggled,ADDR_PIN_BASE+1));
+    printf( " VSS 20        %d < 21 A0  \n", TST_PIN(toggled,ADDR_PIN_BASE+0));
+    printf( "__________________________\n");
+    printf( "\033[u");
+#endif
+#ifdef OCULA
+    printf( "\033[s\033[0;0H");
+    printf( "____________USB___________\n");
+    printf( " MUX 01 -      %d < 40 MA6 \n", TST_PIN(toggled,ADDR_PIN_BASE+6));
+    printf( " MA5 02 > %d    %d < 39 MA7 \n", TST_PIN(toggled,ADDR_PIN_BASE+5), TST_PIN(toggled,ADDR_PIN_BASE+7));
+    printf( " MA4 03 > %d    %d < 38 MA0 \n", TST_PIN(toggled,ADDR_PIN_BASE+4), TST_PIN(toggled,ADDR_PIN_BASE+0));
+    printf( " MA3 04 > %d    %d < 37 MA2 \n", TST_PIN(toggled,ADDR_PIN_BASE+3), TST_PIN(toggled,ADDR_PIN_BASE+2));
+    printf( "  D5 05 > %d    %d < 36 MA1  \n", TST_PIN(toggled,DATA_PIN_BASE+5), TST_PIN(toggled,ADDR_PIN_BASE+1));
+    printf( " GND 06        %d < 35 A12  \n", TST_PIN(toggled,ADDR_PIN_BASE+12));
+    printf( " XT1 07 -      %d < 34 D6   \n", TST_PIN(toggled,DATA_PIN_BASE+6));
+    printf( "  D0 08 > %d    %d < 33 A9   \n", TST_PIN(toggled,DATA_PIN_BASE+0), TST_PIN(toggled,ADDR_PIN_BASE+9));
+    printf( " RAS 09 -      %d < 32 A8   \n", TST_PIN(toggled,ADDR_PIN_BASE+8));
+    printf( " CAS 10 -      %d < 31 A10   \n", TST_PIN(toggled,ADDR_PIN_BASE+10));
+    printf( "  D2 11 > %d    %d < 30 A15   \n", TST_PIN(toggled,DATA_PIN_BASE+2), TST_PIN(toggled,ADDR_PIN_BASE+15));
+    printf( "  D3 12 > %d    %d < 29 A14   \n", TST_PIN(toggled,DATA_PIN_BASE+3), TST_PIN(toggled,ADDR_PIN_BASE+14));
+    printf( "  D4 13 > %d      - 28 WEN   \n", TST_PIN(toggled,DATA_PIN_BASE+4));
+    printf( "PHI0 14 <      %d < 27 RNW_IN\n", TST_PIN(toggled,RNW_PIN));
+    printf( " A11 15 > %d    %d < 26 NMAP  \n", TST_PIN(toggled,ADDR_PIN_BASE+11), TST_PIN(toggled,NMAP_PIN));
+    printf( "SYNC 16 <        > 25 IO    \n");
+    printf( "  D1 17 > %d        24 VSS   \n", TST_PIN(toggled,DATA_PIN_BASE+1));
+    printf( "  D7 18 > %d      > 23 ROMSEL\n", TST_PIN(toggled,DATA_PIN_BASE+7));
+    printf( " BLU 19 <      %d < 22 A13  \n", TST_PIN(toggled,ADDR_PIN_BASE+13));
+    printf( " GRN 20 <        > 21 RED  \n");
+    printf( "__________________________\n");
+    printf( "\033[u");
+#endif
+}
+
+void tst_mon_test(const char *args, size_t len){
+    if(parse_end(args,len)){  //No arguments
+        toggled = 0;
+        testing = true;
+    }else{
+        testing = false;
+    }
+}

--- a/src/firmware/sys/tst.h
+++ b/src/firmware/sys/tst.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Sodiumlightbaby
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+ #ifndef _TST_H_
+ #define _TST_H_
+ 
+ #include <stdbool.h>
+ #include <stddef.h>
+
+  
+ void tst_init(void);
+ void tst_task(void);
+ void tst_print_status(void);
+ void tst_mon_test(const char *args, size_t len);
+
+ #endif /* _TST_H_ */
+ 


### PR DESCRIPTION
Testing mode to help indetify possible input pins not properly connected to the RP2350 during manufacturing.
Running test command in the monitor enables a running display showing input pins on the device and if toggling input has been registered.