### PR TITLE
Add SET BIAS config for PIVIC audio output bias.

### DIFF
--- a/src/firmware/mon/hlp.c
+++ b/src/firmware/mon/hlp.c
@@ -31,7 +31,11 @@ static const char __in_flash("helptext") hlp_text_set[] =
     "SET SPLASH (0|1)    - Query or set  splash screen disable or enable.\n"
     "SET DVI (0|1|2|..)  - Query or set display type for DVI output.\n"
     "SET AUDIO (0|1)     - Query or set DVI audio disable or enable.\n"
-    "SET MODE (0|1|2|..) - Query or set main operational mode.";
+#ifdef PIVIC
+    "SET BIAS (n)        - Adjust the DC bias on the analogue audio.\n"
+#endif
+    "SET MODE (0|1|2|..) - Query or set main operational mode."
+    ;
 
 static const char __in_flash("helptext") hlp_text_about[] =
     "    OCULA & PIVIC - Copyright (c) 2025 Sodiumlightbaby & Dreamseal\n"
@@ -191,7 +195,12 @@ static const char __in_flash("helptext") hlp_text_dvi_audio[] =
 ;
 
 #ifdef PIVIC
-static const char __in_flash("helptext") hlp_text_colour[] =
+static const char __in_flash("helptext") hlp_text_bias[] =
+    "SET BIAS adjust the DC audio bias on the analogue output.\n"
+    "Audio will drop out if too low and clip if too high\n"
+    "Default is 48. 32 can work for many. 64 is 50% bias\n";
+
+    static const char __in_flash("helptext") hlp_text_colour[] =
     "COLOUR|COLOR selects a single palette entry\n"
     "for tuning with the TUNE command. Use 0-15\n"
     "to select each of the 16 colours, or 16 for\n"
@@ -270,6 +279,9 @@ static struct
     {3, "dvi", hlp_text_dvi},
     {5, "audio", hlp_text_dvi_audio},
     {4, "mode", hlp_text_mode},
+#ifdef PIVIC
+    {4, "bias", hlp_text_bias},
+#endif
 };
 static const size_t SETTINGS_COUNT = sizeof SETTINGS / sizeof *SETTINGS;
 

--- a/src/firmware/mon/set.c
+++ b/src/firmware/mon/set.c
@@ -257,6 +257,26 @@ static void set_volt(const char *args, size_t len)
     set_print_volt();
 }
 
+static void set_print_bias()
+{
+    printf("BIAS  : %d\n", cfg_get_bias());
+}
+
+static void set_bias(const char *args, size_t len)
+{
+    uint32_t val;
+    if (len)
+    {
+        if (!parse_uint32(&args, &len, &val) ||
+            !parse_end(args, len) ||
+            !cfg_set_bias(val))
+        {
+            printf("?invalid argument\n");
+            return;
+        }
+    }
+    set_print_bias();
+}
 
 typedef void (*set_function)(const char *, size_t);
 static struct
@@ -272,7 +292,8 @@ static struct
     {3, "dvi", set_dvi},
     {5, "audio", set_dvi_audio},
     {4, "mode", set_mode},
-    {4, "volt", set_volt}
+    {4, "volt", set_volt},
+    {4, "bias", set_bias}
 };
 static const size_t SETTERS_COUNT = sizeof SETTERS / sizeof *SETTERS;
 
@@ -286,6 +307,7 @@ static void set_print_all(void)
     set_print_dvi_audio();
     set_print_mode();
     set_print_volt();
+    set_print_bias();
 }
 
 void set_mon_set(const char *args, size_t len)

--- a/src/firmware/sys/cfg.c
+++ b/src/firmware/sys/cfg.c
@@ -36,6 +36,7 @@ static uint8_t cfg_dvi_mode = 0;
 static uint8_t cfg_dvi_audio = 1;
 static uint8_t cfg_mode = 1;
 static uint8_t cfg_volt = 0;
+static uint8_t cfg_bias = 48;
 
 // Optional string can replace boot string
 static void cfg_save_with_boot_opt(char *opt_str)
@@ -76,6 +77,7 @@ static void cfg_save_with_boot_opt(char *opt_str)
                                "+A%d\n"
                                "+M%d\n"
                                "+U%d\n"
+                               "+B%d\n"
                                "%s",
                                CFG_VERSION,
                                cfg_phi2_khz,
@@ -85,6 +87,7 @@ static void cfg_save_with_boot_opt(char *opt_str)
                                cfg_dvi_audio,
                                cfg_mode,
                                cfg_volt,
+                               cfg_bias,
                                opt_str);
         if (lfsresult < 0)
             printf("?Unable to write %s contents (%d)\n", filename, lfsresult);
@@ -143,6 +146,9 @@ static void cfg_load_with_boot_opt(bool boot_only)
                 break;
             case 'U':
                 cfg_volt = val;
+                break;
+            case 'B':
+                cfg_bias = val;
             default:
                 break;
             }
@@ -298,4 +304,21 @@ bool cfg_set_volt(uint8_t volt)
 uint8_t cfg_get_volt(void)
 {
     return cfg_volt;
+}
+
+bool cfg_set_bias(uint8_t bias)
+{
+    if(bias > 127){
+        return false;
+    }
+    if(cfg_bias != bias){
+        cfg_bias = bias;
+        cfg_save_with_boot_opt(NULL);
+    }
+    return true;
+}
+
+uint8_t cfg_get_bias(void)
+{
+    return cfg_bias;
 }

--- a/src/firmware/sys/cfg.h
+++ b/src/firmware/sys/cfg.h
@@ -34,5 +34,7 @@ bool cfg_set_mode(uint8_t mode);
 uint8_t cfg_get_mode(void);
 bool cfg_set_volt(uint8_t volt);
 uint8_t cfg_get_volt(void);
+bool cfg_set_bias(uint8_t bias);
+uint8_t cfg_get_bias(void);
 
 #endif /* _CFG_H_ */

--- a/src/firmware/vic/aud.c
+++ b/src/firmware/vic/aud.c
@@ -7,6 +7,7 @@
 
 #include "main.h"
 #include "vic/aud.h"
+#include "sys/cfg.h"
 #include "sys/dvi_audio.h"
 #include "sys/mem.h"
 #include "hardware/dma.h"
@@ -61,7 +62,7 @@ volatile audio_sample_t pwm_sample;
 
 void aud_update_pwm(void){
     int16_t pwm_value_signed = ( aud_val[0] + aud_val[1] + aud_val[2] + aud_val[3] ) * (VIC_CRE & 0x0F);
-    uint8_t sample = (uint8_t)(pwm_value_signed + 32);  //DC offset required for bias of mainboard audio circuit
+    uint8_t sample = (uint8_t)(pwm_value_signed + cfg_get_bias());  //DC offset required for bias of mainboard audio circuit
     pwm_set_chan_level(AUDIO_PWM_SLICE, AUDIO_PWM_CH, sample);    
     pwm_sample.left = sample << 5;
     pwm_sample.right = sample << 5;
@@ -117,9 +118,9 @@ void aud_task(void){
         aud_calc_voice(2, aud_regs.ch[2]);
         if(upd & 0x08)
             aud_step_noise(upd >> 24);
-        if(dvi_audio_fs_tick())
-            aud_update_pwm();
     }
+    if(dvi_audio_fs_tick())
+        aud_update_pwm();
 }
 
 void aud_print_status(void){


### PR DESCRIPTION
PIVIC analogue audio output is requires a DC bias for the VIC-20 mother board audio circuit not to cut it out. To give good volume on the 7-bit DAC (range 128) a fixed DC bias of 32 was used, but some users reported audio dropouts indicating this value is marginal. The new default has been set to 48 and made configurable with a monitor "SET BIAS" command so those who want to add more headroom (and reduce clipping) can lower the bias to their preferred level.